### PR TITLE
Re-enable pretty print for development

### DIFF
--- a/services/api/src/utils/logger.ts
+++ b/services/api/src/utils/logger.ts
@@ -7,7 +7,5 @@ import { Configuration } from '../configuration'
  */
 export const logger = pino({
   level: Configuration.logLevel,
-  ...(Configuration.env !== 'production' && {
-    transport: { target: 'pino-pretty' },
-  }),
+  prettyPrint: Configuration.env !== 'production',
 })

--- a/services/api/src/utils/logger.ts
+++ b/services/api/src/utils/logger.ts
@@ -8,4 +8,8 @@ import { Configuration } from '../configuration'
 export const logger = pino({
   level: Configuration.logLevel,
   prettyPrint: Configuration.env !== 'production',
+  // Use this with pino v7
+  // ...(Configuration.env !== 'production' && {
+  //   transport: { target: 'pino-pretty' },
+  // }),
 })


### PR DESCRIPTION
This ensures the API's logging is pretty-printed during development.