### PR TITLE
Hide auction filters when auctions are filtered out

### DIFF
--- a/apps/web/src/components/releases/release-filter-type.tsx
+++ b/apps/web/src/components/releases/release-filter-type.tsx
@@ -39,56 +39,57 @@ export default function ReleaseFilterType() {
           />
         </div>
       </div>
-
-      {state.showAuction && (<>
-        <div className={clsx(css.filterRow, css.filterHeader)}>
-          <Heading level={2}>{t('release:filters.Auction Status')}</Heading>
+      <div className={clsx(css.filterRow, css.filterHeader)}>
+        <Heading level={2}>{t('release:filters.Auction Status')}</Heading>
+      </div>
+      <div className={css.filterRow}>
+        <div className={css.filterItem}>
+          <Toggle
+            checked={state.showAuctionUpcoming}
+            disabled={!state.showAuction}
+            label={t('release:filters.Starting soon')}
+            onChange={(checked) => {
+              dispatch(packFilterActions.setShowAuctionUpcoming(checked))
+            }}
+            styleMode="dark"
+          />
         </div>
-        <div className={css.filterRow}>
-          <div className={css.filterItem}>
-            <Toggle
-              checked={state.showAuctionUpcoming}
-              label={t('release:filters.Starting soon')}
-              onChange={(checked) => {
-                dispatch(packFilterActions.setShowAuctionUpcoming(checked))
-              }}
-              styleMode="dark"
-            />
-          </div>
-          <div className={css.filterItem}>
-            <Toggle
-              checked={state.showAuctionActive}
-              label={t('release:filters.Auction is live')}
-              onChange={(checked) => {
-                dispatch(packFilterActions.setShowAuctionActive(checked))
-              }}
-              styleMode="dark"
-            />
-          </div>
-          <div className={css.filterItem}>
-            <Toggle
-              checked={state.showAuctionExpired}
-              label={t('release:filters.Has ended')}
-              onChange={(checked) => {
-                dispatch(packFilterActions.setShowAuctionExpired(checked))
-              }}
-              styleMode="dark"
-            />
-          </div>
+        <div className={css.filterItem}>
+          <Toggle
+            checked={state.showAuctionActive}
+            disabled={!state.showAuction}
+            label={t('release:filters.Auction is live')}
+            onChange={(checked) => {
+              dispatch(packFilterActions.setShowAuctionActive(checked))
+            }}
+            styleMode="dark"
+          />
         </div>
-        <div className={css.filterRow}>
-          <div className={css.filterItem}>
-            <Toggle
-              checked={state.showAuctionReserveMet}
-              label={t('release:filters.Reserve met')}
-              onChange={(checked) => {
-                dispatch(packFilterActions.setShowAuctionReserveMet(checked))
-              }}
-              styleMode="dark"
-            />
-          </div>
+        <div className={css.filterItem}>
+          <Toggle
+            checked={state.showAuctionExpired}
+            disabled={!state.showAuction}
+            label={t('release:filters.Has ended')}
+            onChange={(checked) => {
+              dispatch(packFilterActions.setShowAuctionExpired(checked))
+            }}
+            styleMode="dark"
+          />
         </div>
-      </>)}
+      </div>
+      <div className={css.filterRow}>
+        <div className={css.filterItem}>
+          <Toggle
+            checked={state.showAuctionReserveMet}
+            disabled={!state.showAuction}
+            label={t('release:filters.Reserve met')}
+            onChange={(checked) => {
+              dispatch(packFilterActions.setShowAuctionReserveMet(checked))
+            }}
+            styleMode="dark"
+          />
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/releases/release-filter-type.tsx
+++ b/apps/web/src/components/releases/release-filter-type.tsx
@@ -39,57 +39,56 @@ export default function ReleaseFilterType() {
           />
         </div>
       </div>
-      <div className={clsx(css.filterRow, css.filterHeader)}>
-        <Heading level={2}>{t('release:filters.Auction Status')}</Heading>
-      </div>
-      <div className={css.filterRow}>
-        <div className={css.filterItem}>
-          <Toggle
-            checked={state.showAuctionUpcoming}
-            disabled={!state.showAuction}
-            label={t('release:filters.Starting soon')}
-            onChange={(checked) => {
-              dispatch(packFilterActions.setShowAuctionUpcoming(checked))
-            }}
-            styleMode="dark"
-          />
+
+      {state.showAuction && (<>
+        <div className={clsx(css.filterRow, css.filterHeader)}>
+          <Heading level={2}>{t('release:filters.Auction Status')}</Heading>
         </div>
-        <div className={css.filterItem}>
-          <Toggle
-            checked={state.showAuctionActive}
-            disabled={!state.showAuction}
-            label={t('release:filters.Auction is live')}
-            onChange={(checked) => {
-              dispatch(packFilterActions.setShowAuctionActive(checked))
-            }}
-            styleMode="dark"
-          />
+        <div className={css.filterRow}>
+          <div className={css.filterItem}>
+            <Toggle
+              checked={state.showAuctionUpcoming}
+              label={t('release:filters.Starting soon')}
+              onChange={(checked) => {
+                dispatch(packFilterActions.setShowAuctionUpcoming(checked))
+              }}
+              styleMode="dark"
+            />
+          </div>
+          <div className={css.filterItem}>
+            <Toggle
+              checked={state.showAuctionActive}
+              label={t('release:filters.Auction is live')}
+              onChange={(checked) => {
+                dispatch(packFilterActions.setShowAuctionActive(checked))
+              }}
+              styleMode="dark"
+            />
+          </div>
+          <div className={css.filterItem}>
+            <Toggle
+              checked={state.showAuctionExpired}
+              label={t('release:filters.Has ended')}
+              onChange={(checked) => {
+                dispatch(packFilterActions.setShowAuctionExpired(checked))
+              }}
+              styleMode="dark"
+            />
+          </div>
         </div>
-        <div className={css.filterItem}>
-          <Toggle
-            checked={state.showAuctionExpired}
-            disabled={!state.showAuction}
-            label={t('release:filters.Has ended')}
-            onChange={(checked) => {
-              dispatch(packFilterActions.setShowAuctionExpired(checked))
-            }}
-            styleMode="dark"
-          />
+        <div className={css.filterRow}>
+          <div className={css.filterItem}>
+            <Toggle
+              checked={state.showAuctionReserveMet}
+              label={t('release:filters.Reserve met')}
+              onChange={(checked) => {
+                dispatch(packFilterActions.setShowAuctionReserveMet(checked))
+              }}
+              styleMode="dark"
+            />
+          </div>
         </div>
-      </div>
-      <div className={css.filterRow}>
-        <div className={css.filterItem}>
-          <Toggle
-            checked={state.showAuctionReserveMet}
-            disabled={!state.showAuction}
-            label={t('release:filters.Reserve met')}
-            onChange={(checked) => {
-              dispatch(packFilterActions.setShowAuctionReserveMet(checked))
-            }}
-            styleMode="dark"
-          />
-        </div>
-      </div>
+      </>)}
     </div>
   )
 }

--- a/apps/web/src/components/toggle/toggle.module.css
+++ b/apps/web/src/components/toggle/toggle.module.css
@@ -50,6 +50,6 @@
 }
 
 .inputDisabled {
-  @apply opacity-30;
+  @apply opacity-50;
   pointer-events: none;
 }

--- a/apps/web/src/components/toggle/toggle.module.css
+++ b/apps/web/src/components/toggle/toggle.module.css
@@ -53,3 +53,7 @@
   @apply opacity-50;
   pointer-events: none;
 }
+
+.inputDisabled + input + .label {
+  @apply text-base-gray-light;
+}

--- a/apps/web/src/components/toggle/toggle.module.css
+++ b/apps/web/src/components/toggle/toggle.module.css
@@ -50,5 +50,6 @@
 }
 
 .inputDisabled {
-  @apply opacity-50;
+  @apply opacity-30;
+  pointer-events: none;
 }


### PR DESCRIPTION
The disabled state for the switch component is indistinguishable from the enabled state. This is better at least for now.
 -- I'd also be happy to take a swing at disabled state styles if people don't like show/hide in this context.
 
### Showing auctions

<img width="261" alt="CleanShot 2021-11-02 at 16 24 33@2x" src="https://user-images.githubusercontent.com/1179515/139946700-b834560b-4f22-4dae-b145-631324f6f8ae.png">

### Hiding auctions

<img width="266" alt="CleanShot 2021-11-02 at 16 24 46@2x" src="https://user-images.githubusercontent.com/1179515/139946710-0ac68042-30ef-4aba-b585-d9f6dc4725c2.png">
