### PR TITLE
Remove TF_VAR_ prefix from github secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,60 +119,60 @@ jobs:
           TF_VAR_project: ${{ secrets.GCP_PROJECT_ID }}
           TF_VAR_credentials: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
 
-          TF_VAR_algod_host: ${{ secrets.TF_VAR_algod_host }}
-          TF_VAR_algod_key: ${{ secrets.TF_VAR_algod_key }}
-          TF_VAR_algod_port: ${{ secrets.TF_VAR_algod_port }}
+          TF_VAR_algod_host: ${{ secrets.ALGOD_HOST }}
+          TF_VAR_algod_key: ${{ secrets.ALGOD_KEY }}
+          TF_VAR_algod_port: ${{ secrets.ALGOD_PORT }}
 
-          TF_VAR_api_creator_passphrase: ${{ secrets.TF_VAR_api_creator_passphrase }}
-          TF_VAR_api_database_user_name: ${{ secrets.TF_VAR_api_database_user_name }}
-          TF_VAR_api_database_user_password: ${{ secrets.TF_VAR_api_database_user_password }}
-          TF_VAR_api_domain_mapping: ${{ secrets.TF_VAR_api_domain_mapping }}
-          TF_VAR_api_funding_mnemonic: ${{ secrets.TF_VAR_api_funding_mnemonic }}
+          TF_VAR_api_creator_passphrase: ${{ secrets.API_CREATOR_PASSPHRASE }}
+          TF_VAR_api_database_user_name: ${{ secrets.API_DATABASE_USER_NAME }}
+          TF_VAR_api_database_user_password: ${{ secrets.API_DATABASE_USER_PASSWORD }}
+          TF_VAR_api_domain_mapping: ${{ secrets.API_DOMAIN_MAPPING }}
+          TF_VAR_api_funding_mnemonic: ${{ secrets.API_FUNDING_MNEMONIC }}
           TF_VAR_api_image: "${{ secrets.GCP_DOCKER_REGISTRY }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_REPOSITORY }}/api:${{ needs.tag.outputs.value }}"
-          TF_VAR_api_key: ${{ secrets.TF_VAR_api_key }}
-          TF_VAR_api_secret: ${{ secrets.TF_VAR_api_secret }}
+          TF_VAR_api_key: ${{ secrets.API_KEY }}
+          TF_VAR_api_secret: ${{ secrets.API_SECRET }}
 
-          TF_VAR_circle_key: ${{ secrets.TF_VAR_circle_key }}
-          TF_VAR_circle_url: ${{ secrets.TF_VAR_circle_url }}
+          TF_VAR_circle_key: ${{ secrets.CIRCLE_KEY }}
+          TF_VAR_circle_url: ${{ secrets.CIRCLE_URL }}
 
-          TF_VAR_cms_admin_email: ${{ secrets.TF_VAR_cms_admin_email }}
-          TF_VAR_cms_admin_password: ${{ secrets.TF_VAR_cms_admin_password }}
-          TF_VAR_cms_database_user_name: ${{ secrets.TF_VAR_cms_database_user_name }}
-          TF_VAR_cms_database_user_password: ${{ secrets.TF_VAR_cms_database_user_password }}
-          TF_VAR_cms_domain_mapping: ${{ secrets.TF_VAR_cms_domain_mapping }}
+          TF_VAR_cms_admin_email: ${{ secrets.CMS_ADMIN_EMAIL }}
+          TF_VAR_cms_admin_password: ${{ secrets.CMS_ADMIN_PASSWORD }}
+          TF_VAR_cms_database_user_name: ${{ secrets.CMS_DATABASE_USER_NAME }}
+          TF_VAR_cms_database_user_password: ${{ secrets.CMS_DATABASE_USER_PASSWORD }}
+          TF_VAR_cms_domain_mapping: ${{ secrets.CMS_DOMAIN_MAPPING }}
           TF_VAR_cms_image: "${{ secrets.GCP_DOCKER_REGISTRY }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_REPOSITORY }}/cms:${{ needs.tag.outputs.value }}"
-          TF_VAR_cms_key: ${{ secrets.TF_VAR_cms_key }}
-          TF_VAR_cms_secret: ${{ secrets.TF_VAR_cms_secret }}
-          TF_VAR_cms_storage_bucket: ${{ secrets.TF_VAR_cms_storage_bucket }}
+          TF_VAR_cms_key: ${{ secrets.CMS_KEY }}
+          TF_VAR_cms_secret: ${{ secrets.CMS_SECRET }}
+          TF_VAR_cms_storage_bucket: ${{ secrets.CMS_STORAGE_BUCKET }}
 
-          TF_VAR_sendgrid_key: ${{ secrets.TF_VAR_sendgrid_key }}
-          TF_VAR_sendgrid_from_email: ${{ secrets.TF_VAR_sendgrid_from_email }}
+          TF_VAR_sendgrid_key: ${{ secrets.SENDGRID_KEY }}
+          TF_VAR_sendgrid_from_email: ${{ secrets.SENDGRID_FROM_EMAIL }}
 
-          TF_VAR_web_domain_mapping: ${{ secrets.TF_VAR_web_domain_mapping }}
-          TF_VAR_web_firebase_service_account: ${{ secrets.TF_VAR_web_firebase_service_account }}
+          TF_VAR_web_domain_mapping: ${{ secrets.WEB_DOMAIN_MAPPING }}
+          TF_VAR_web_firebase_service_account: ${{ secrets.WEB_FIREBASE_SERVICE_ACCOUNT }}
           TF_VAR_web_image: "${{ secrets.GCP_DOCKER_REGISTRY }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_REPOSITORY }}/web:${{ needs.tag.outputs.value }}"
-          TF_VAR_web_next_public_firebase_config: ${{ secrets.TF_VAR_web_next_public_firebase_config }}
+          TF_VAR_web_next_public_firebase_config: ${{ secrets.WEB_NEXT_PUBLIC_FIREBASE_CONFIG }}
 
           # Optional
-          TF_VAR_region: ${{ secrets.TF_VAR_region }}
-          TF_VAR_database_server_tier: ${{ secrets.TF_VAR_database_server_tier }}
+          TF_VAR_region: ${{ secrets.REGION }}
+          TF_VAR_database_server_tier: ${{ secrets.DATABASE_SERVER_TIER }}
 
-          TF_VAR_api_service_name: ${{ secrets.TF_VAR_api_service_name }}
-          TF_VAR_cms_service_name: ${{ secrets.TF_VAR_cms_service_name }}
-          TF_VAR_database_server_name: ${{ secrets.TF_VAR_database_server_name }}
-          TF_VAR_private_ip_name: ${{ secrets.TF_VAR_private_ip_name }}
-          TF_VAR_vpc_name: ${{ secrets.TF_VAR_vpc_name }}
-          TF_VAR_vpc_access_connector_name: ${{ secrets.TF_VAR_vpc_access_connector_name }}
-          TF_VAR_web_service_name: ${{ secrets.TF_VAR_web_service_name }}
+          TF_VAR_api_service_name: ${{ secrets.API_SERVICE_NAME }}
+          TF_VAR_cms_service_name: ${{ secrets.CMS_SERVICE_NAME }}
+          TF_VAR_database_server_name: ${{ secrets.DATABASE_SERVER_NAME }}
+          TF_VAR_private_ip_name: ${{ secrets.PRIVATE_IP_NAME }}
+          TF_VAR_vpc_name: ${{ secrets.VPC_NAME }}
+          TF_VAR_vpc_access_connector_name: ${{ secrets.VPC_ACCESS_CONNECTOR_NAME }}
+          TF_VAR_web_service_name: ${{ secrets.WEB_SERVICE_NAME }}
 
-          TF_VAR_api_database_name: ${{ secrets.TF_VAR_api_database_name }}
-          TF_VAR_api_database_schema: ${{ secrets.TF_VAR_api_database_schema }}
-          TF_VAR_api_node_env: ${{ secrets.TF_VAR_api_node_env }}
+          TF_VAR_api_database_name: ${{ secrets.API_DATABASE_NAME }}
+          TF_VAR_api_database_schema: ${{ secrets.API_DATABASE_SCHEMA }}
+          TF_VAR_api_node_env: ${{ secrets.API_NODE_ENV }}
 
-          TF_VAR_cms_database_name: ${{ secrets.TF_VAR_cms_database_name }}
-          TF_VAR_cms_node_env: ${{ secrets.TF_VAR_cms_node_env }}
+          TF_VAR_cms_database_name: ${{ secrets.CMS_DATABASE_NAME }}
+          TF_VAR_cms_node_env: ${{ secrets.CMS_NODE_ENV }}
 
-          TF_VAR_web_node_env: ${{ secrets.TF_VAR_web_node_env }}
+          TF_VAR_web_node_env: ${{ secrets.WEB_NODE_ENV }}
 
         # It's necessary to `unset` any `TF_VAR_*` variables if they're empty; otherwise
         # Terraform will override default values with empty ones. This needs to be done


### PR DESCRIPTION
Passing Terraform input variables in via environment variables requires a specific convention, namely that a variable called `my_variable` would be passed in via `TF_VAR_my_variable=... terraform apply`.

This convention was followed with the github secrets themselves, meaning the [deploy file](https://github.com/deptagency/algomart/blob/6f7f3f1cac2588c9d44c01447c01f397c53b3cd1/.github/workflows/deploy.yml#L126) had lines like...

```
TF_VAR_api_creator_passphrase: ${{ secrets.TF_VAR_api_creator_passphrase }}
```

Since all of the environment variables had to be manually mapped to pass them through to Terraform, following that convention was unnecessary. Furthermore, it introduces some confusion because creating a new Github Secret named `TF_VAR_api_creator_passphrase` _looks like_ it saves as `TF_VAR_API_CREATOR_PASSPHRASE` even though it's referenced as `secrets.TF_VAR_api_creator_passphrase` in the workflows themselves.

This PR updates the deploy workflow to expect secrets that no longer have the `TF_VAR_` prefix and also are all-caps, eg:

```
TF_VAR_api_creator_passphrase: ${{ secrets.API_CREATOR_PASSPHRASE }}
```