### PR TITLE
Target development environment in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    environment: development
     needs:
       - tag
     strategy:
@@ -81,6 +82,7 @@ jobs:
 
   terraform:
     runs-on: ubuntu-latest
+    environment: development
     needs:
       - tag
       - build


### PR DESCRIPTION
This PR changes the deploy workflow to use the `development` environment (which is configured with secrets). An environment isn't strictly necessary, but it makes it easier to expand the deployed environment setup if desired.