### PR TITLE
[#37] Login prompt, minor improvements

### DIFF
--- a/apps/web/locales/en-US/release.json
+++ b/apps/web/locales/en-US/release.json
@@ -27,6 +27,7 @@
   "listedByAuctions": "Listed by {{username}}, auction begins {{date}}",
   "Live auction ends in": "Live auction ⏰ ends in",
   "Live auction starts in": "Live auction ⏰ starts in",
+  "loginPrompt": "<0>Login or create an account</0> to begin collecting!",
   "Met": "Met",
   "Mint Cost": "Mint Cost",
   "N of N editions available": "{{available}} of {{total}} editions available",

--- a/apps/web/src/components/app-header/app-header.tsx
+++ b/apps/web/src/components/app-header/app-header.tsx
@@ -20,6 +20,8 @@ export default function AppHeader() {
   const navItems = getMainNavItems(t)
   const { pathname } = useRouter()
 
+  const isAuthenticated = auth.status === 'authenticated'
+
   return (
     <header
       className={clsx(css.root, {
@@ -73,10 +75,18 @@ export default function AppHeader() {
         {/* Utility Nav */}
         <div className={css.utilityNav}>
           <AppLink
-            aria-label={t('common:nav.utility.Log In')}
+            aria-label={
+              isAuthenticated
+                ? t('common:pageTitles.My Profile')
+                : t('common:nav.utility.Log In')
+            }
             className={css.utilityNavLink}
-            href={auth.status === 'authenticated' ? urls.myProfile : urls.login}
-            title={t('common:nav.utility.Log In')}
+            href={isAuthenticated ? urls.myProfile : urls.login}
+            title={
+              isAuthenticated
+                ? t('common:pageTitles.My Profile')
+                : t('common:nav.utility.Log In')
+            }
           >
             {auth.user?.photo ? (
               <Image

--- a/apps/web/src/components/login-panel/login-panel.module.css
+++ b/apps/web/src/components/login-panel/login-panel.module.css
@@ -1,15 +1,15 @@
 .root {
   /* Base */
-  @apply mx-auto relative;
+  @apply relative mx-auto;
   /* Tablet + */
   @apply md:max-w-520 md:overflow-hidden md:rounded-xl;
 }
 
 .buttonContainer {
   /* Base */
-  @apply bg-base-teal flex flex-col px-8 py-12 space-y-8;
+  @apply flex flex-col px-8 py-12 space-y-8 bg-base-teal;
   /* Mobile + */
-  @apply sm:px-24 sm:py-16;
+  @apply sm:p-16;
 }
 
 .button {
@@ -30,11 +30,11 @@
 
 .featuredBottom {
   /* Base */
-  @apply mx-auto px-8 py-12 relative;
+  @apply relative px-8 py-12 mx-auto;
   /* Mobile + */
   @apply sm:px-24;
 }
 
 .featuredBottomText {
-  @apply mt-8 text-center text-lg text-white;
+  @apply mt-8 text-lg text-center text-white;
 }

--- a/apps/web/src/components/login-panel/login-panel.tsx
+++ b/apps/web/src/components/login-panel/login-panel.tsx
@@ -46,8 +46,8 @@ export default function LoginPanel({
               variant="secondary"
             >
               <Image
-                width={48}
-                height={48}
+                width={36}
+                height={36}
                 alt={t('auth:Google logo')}
                 src={googleIcon}
               />

--- a/apps/web/src/components/release-details/sections/release-cta.module.css
+++ b/apps/web/src/components/release-details/sections/release-cta.module.css
@@ -6,7 +6,11 @@
   @apply relative max-w-xs mx-auto;
 }
 
-.limit1PerCustomer {
+.loginPrompt {
+  @apply text-center;
+}
+
+.actionNotAllowed {
   @apply text-center text-base-errorRed;
 }
 

--- a/apps/web/src/components/release-details/sections/release-cta.tsx
+++ b/apps/web/src/components/release-details/sections/release-cta.tsx
@@ -1,9 +1,14 @@
 import { PackStatus, PackType } from '@algomart/schemas'
+import { useRouter } from 'next/router'
+import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 
 import css from './release-cta.module.css'
 
+import AppLink from '@/components/app-link/app-link'
 import Button from '@/components/button'
+import { useAuth } from '@/contexts/auth-context'
+import { urls } from '@/utils/urls'
 
 export interface ReleaseCTAProps {
   disallowBuyOrClaim: boolean | null
@@ -24,6 +29,8 @@ export default function ReleaseCTA({
   status,
   type,
 }: ReleaseCTAProps) {
+  const { user } = useAuth()
+  const { asPath } = useRouter()
   const { t } = useTranslation()
   const getText = () => {
     if (type === PackType.Purchase) return t('common:actions.Purchase')
@@ -36,12 +43,25 @@ export default function ReleaseCTA({
     return t('common:actions.Claim My Edition')
   }
 
+  if (!user) {
+    return (
+      <div className={css.root}>
+        <p className={css.loginPrompt}>
+          <Trans
+            components={[
+              <AppLink key={1} href={`${urls.login}?redirect=${asPath}`} />,
+            ]}
+            i18nKey="release:loginPrompt"
+          />
+        </p>
+      </div>
+    )
+  }
+
   if (!releaseIsAvailable) {
     return (
       <div className={css.root}>
-        <p className={css.limit1PerCustomer}>
-          {t('release:noLongerAvailable')}
-        </p>
+        <p className={css.actionNotAllowed}>{t('release:noLongerAvailable')}</p>
       </div>
     )
   }
@@ -49,9 +69,7 @@ export default function ReleaseCTA({
   if (disallowBuyOrClaim) {
     return (
       <div className={css.root}>
-        <p className={css.limit1PerCustomer}>
-          {t('release:limit1PerCustomer')}
-        </p>
+        <p className={css.actionNotAllowed}>{t('release:limit1PerCustomer')}</p>
       </div>
     )
   }

--- a/apps/web/src/pages/releases/[packSlug].tsx
+++ b/apps/web/src/pages/releases/[packSlug].tsx
@@ -118,9 +118,6 @@ export default function ReleasePage({
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const user = await getAuthenticatedUser(context)
-  if (!user) {
-    return handleUnauthenticatedRedirect(context.resolvedUrl)
-  }
 
   const { packs: packTemplates } = await ApiClient.instance.getPublishedPacks({
     locale: context.locale || DEFAULT_LOCALE,

--- a/apps/web/src/templates/release-template.tsx
+++ b/apps/web/src/templates/release-template.tsx
@@ -15,6 +15,7 @@ import MediaGallery from '@/components/media-gallery/media-gallery'
 import ClaimNFTModal from '@/components/modals/claim-nft-modal'
 import Notification from '@/components/notification/notification'
 import ReleaseDetails from '@/components/release-details/release-details'
+import { useAuth } from '@/contexts/auth-context'
 import { isAfterNow } from '@/utils/date-time'
 
 export interface ReleaseTemplateProps {
@@ -43,6 +44,7 @@ export default function ReleaseTemplate({
   packAuction,
   packTemplate,
 }: ReleaseTemplateProps) {
+  const { user } = useAuth()
   const { push } = useRouter()
   const { t } = useTranslation()
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
@@ -59,8 +61,9 @@ export default function ReleaseTemplate({
     !isEnded
   const isInFuture = startDateTime && isAfterNow(new Date(startDateTime))
   const isAlertDisplayed =
-    (packType === PackType.Purchase && isActive) ||
-    (packType === PackType.Auction && !isOwner)
+    user &&
+    ((packType === PackType.Purchase && isActive) ||
+      (packType === PackType.Auction && !isOwner))
 
   const handleClaimNFTFlow = () => {
     packType === PackType.Purchase || packType === PackType.Auction


### PR DESCRIPTION
Closes #37 

Currently, the `/releases/[pack-slug]` page forces end users into a login redirect flow. Ideally, they should be able to access this page when authenticated, but not take any actions to purchase, claim, bid, or redeem:
<img width="788" alt="Screen Shot 2021-11-04 at 11 58 24 AM" src="https://user-images.githubusercontent.com/658485/140376651-7a258ffa-183d-4578-83b8-653ade336c78.png">

Other minor improvements while I was in there:
- The user avatar in the top right had a title of "Log In" regardless of authentication state. It now says "Log In" when unauthenticated, and "My Profile when authenticated.
- I noticed the padding in the login panel was causing the Google button to wrap to two lines at certain screensizes. Not sure how this was introduced, but should be good now.