### PR TITLE
Video fit and finish

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,5 @@ If you have a general question about AlgoMart, you can create a [new question][n
 the issue tracker is only for bugs and feature requests.
 
 [code of conduct]: [CODE_OF_CONDUCT.md]
-[new issue]: https://github.com/rocketinsights/algorand-marketplace/issues/new/choose
-[new question]: https://github.com/rocketinsights/algorand-marketplace/discussions/new
+[new issue]: https://github.com/deptagency/algomart/issues/new/choose
+[new question]: https://github.com/deptagency/algomart/discussions/new

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ npm run test:api -- --watch
 [directus]: https://directus.io
 [firebase]: https://firebase.google.com/
 [gcp]: https://cloud.google.com
-[issue tracker]: https://github.com/rocketinsights/algorand-marketplace/issues
+[issue tracker]: https://github.com/deptagency/algomart/issues
 [nvm]: https://github.com/nvm-sh/nvm
 [postgres app]: https://postgresapp.com
 [schemas]: packages/schemas

--- a/apps/web/src/components/collectibles/collectible-browser.module.css
+++ b/apps/web/src/components/collectibles/collectible-browser.module.css
@@ -80,12 +80,10 @@
 
 .flipBoxFront,
 .flipBoxBack {
-  @apply absolute;
-  @apply w-full h-full;
+  @apply absolute w-full h-full bg-black;
   backface-visibility: hidden;
 }
 
 .flipBoxFront {
   @apply flex text-center;
-  @apply bg-opacity-50 bg-black;
 }

--- a/apps/web/src/components/collectibles/collectible-browser.tsx
+++ b/apps/web/src/components/collectibles/collectible-browser.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import useTranslation from 'next-translate/useTranslation'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import css from './collectible-browser.module.css'
 
@@ -24,6 +24,7 @@ export default function CollectibleBrowser({
   const [showVideoCoverImage, setShowVideoCoverImage] = useState(false)
   const collectible = collectibles[current]
 
+  const videoReference = useRef<HTMLVideoElement>(null)
   const router = useRouter()
   const { t } = useTranslation()
 
@@ -72,7 +73,14 @@ export default function CollectibleBrowser({
       <Heading className={css.title}>{collectible.title}</Heading>
       {collectible.previewVideo && (
         <button
-          onClick={() => setShowVideoCoverImage(!showVideoCoverImage)}
+          onClick={() => {
+            setShowVideoCoverImage(!showVideoCoverImage)
+            if (!showVideoCoverImage) {
+              videoReference.current?.pause()
+            } else {
+              videoReference.current?.play()
+            }
+          }}
           className={css.flipButton}
         >
           {showVideoCoverImage ? 'show video' : 'show cover'}
@@ -101,6 +109,7 @@ export default function CollectibleBrowser({
                 https://stackoverflow.com/questions/29291688/video-displayed-in-reactjs-component-not-updating 
                 */}
                 <video
+                  ref={videoReference}
                   width="100%"
                   controls
                   muted

--- a/apps/web/src/components/collectibles/collectible-browser.tsx
+++ b/apps/web/src/components/collectibles/collectible-browser.tsx
@@ -48,6 +48,15 @@ export default function CollectibleBrowser({
     })
   }, [collectibles])
 
+  const handleFlip = useCallback(() => {
+    setShowVideoCoverImage(!showVideoCoverImage)
+    if (!showVideoCoverImage) {
+      videoReference.current?.pause()
+    } else {
+      videoReference.current?.play()
+    }
+  }, [showVideoCoverImage])
+
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       switch (event.key) {
@@ -72,17 +81,7 @@ export default function CollectibleBrowser({
     <div className={css.root}>
       <Heading className={css.title}>{collectible.title}</Heading>
       {collectible.previewVideo && (
-        <button
-          onClick={() => {
-            setShowVideoCoverImage(!showVideoCoverImage)
-            if (!showVideoCoverImage) {
-              videoReference.current?.pause()
-            } else {
-              videoReference.current?.play()
-            }
-          }}
-          className={css.flipButton}
-        >
+        <button onClick={handleFlip} className={css.flipButton}>
           {showVideoCoverImage ? 'show video' : 'show cover'}
         </button>
       )}


### PR DESCRIPTION
Set background of flip cards to black so varying image sizes don't accidentally show-through to the back side of the video (per feedback from Ian).

Also automatically play/pause on flip so we don't waste cpu and so we can support audio in the future if need-be.

https://user-images.githubusercontent.com/1179515/140423529-e742efe4-c23e-40a1-b8fb-a21e1ce6dc07.mp4
(opacity set to 50% so you can see the automatic play/pause on flip)

