### PR TITLE
Set log level always on directus user count

### DIFF
--- a/apps/cms/scripts/bootstrap.mjs
+++ b/apps/cms/scripts/bootstrap.mjs
@@ -37,7 +37,7 @@ async function main(args) {
   console.log('Bootstrapping Directus...')
   await execCommandAndGetOutput('npx directus bootstrap --skipAdminInit')
   const usersCount = await execCommandAndGetOutput(
-    'npx directus count directus_users'
+    'LOG_LEVEL=warn npx directus count directus_users'
   )
   if (Number.parseInt(usersCount, 10) < 1) {
     console.log('Creating initial admin user...')


### PR DESCRIPTION
Fixes situation where admin user wouldn't get created if LOG_LEVEL wasn't set due to an additional log statement.

<img width="768" alt="Screen Shot 2021-11-05 at 2 36 01 PM" src="https://user-images.githubusercontent.com/781839/140581409-58751930-fdc4-4edb-9203-51563454a5e2.png">
