### PR TITLE
Documentation fixes & additions

### DIFF
--- a/docs/deploy/04-github-secrets/README.md
+++ b/docs/deploy/04-github-secrets/README.md
@@ -23,6 +23,8 @@ These were the host names we used when
 [configuring DNS records](../02-dns-registration/README.md)
 for domain-mapping.
 
+These **MUST NOT** include `https://` prefix.
+
 | Variable             | Example             |
 | -------------------- | ------------------- |
 | `API_DOMAIN_MAPPING` | api.dev.example.com |
@@ -46,12 +48,12 @@ to both an `algod` node (on MainNet or TestNet, depending on environment)
 and a "funding account" that can issue transactions to create
 new accounts, fund asset creation, etc.
 
-| Variable               | Description                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------- |
-| `ALGOD_HOST`           | The host name of the `algod` server **with protocol** (ie. "https://{host-name}") |
-| `ALGOD_KEY`            | The access token for the `algod` server                                           |
-| `ALGOD_PORT`           | The port for the `algod` server                                                   |
-| `API_FUNDING_MNEMONIC` | The 25-word mnemonic for the master funding account                               |
+| Variable               | Description                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `ALGOD_HOST`           | The host name of the `algod` server - this **MUST** include `https://` prefix. |
+| `ALGOD_KEY`            | The access token for the `algod` server                                        |
+| `ALGOD_PORT`           | The port for the `algod` server                                                |
+| `API_FUNDING_MNEMONIC` | The 25-word mnemonic for the master funding account                            |
 
 **Important:** The funding account used **must have funds** before
 the app can be used. Without funds, admins cannot create NFTs,
@@ -61,10 +63,10 @@ users cannot create accounts, etc.
 
 Circle is used for processing payments.
 
-| Variable     | Description                                                         |
-| ------------ | ------------------------------------------------------------------- |
-| `CIRCLE_KEY` | The private API key                                                 |
-| `CIRCLE_URL` | The environment-specific URL for the API, ie. sandbox or production |
+| Variable     | Description                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------- |
+| `CIRCLE_KEY` | The private API key                                                                                            |
+| `CIRCLE_URL` | The environment-specific URL for the API, ie. sandbox or production - this **MUST** include `https://` prefix. |
 
 ### Sendgrid
 
@@ -85,20 +87,20 @@ storefront from decrypting necessary values,
 or it might cause Terraform to try to destroy stateful resources
 like the database or storage bucket, etc.
 
-| Variable                     | Description                                                                                                 | Changeable                                                                                                      |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `API_CREATOR_PASSPHRASE`     | The secret used to encrypt new Algorand account mnemonics so they can be (reasonably) safely stored at rest | **NO** - Will prevent application from decrypting the mnemonics for the API-generated asset creator accounts    |
-| `API_DATABASE_USER_NAME`     | The name for the API application's database user                                                            | TODO                                                                                                            |
-| `API_DATABASE_USER_PASSWORD` | The password for the API application's database user                                                        | TODO                                                                                                            |
-| `API_KEY`                    | For authentication with the API                                                                             | TODO                                                                                                            |
-| `API_SECRET`                 | Private secret used in encryption                                                                           | **NO**                                                                                                          |
-| `CMS_ADMIN_EMAIL`            | The email address for the initial admin user created by Directus                                            | **NO** - Changing has no effect, since Directus only bootstraps the user on first run                           |
-| `CMS_ADMIN_PASSWORD`         | The password for the initial admin user created by Directus                                                 | **NO** - Changing has no effect, since Directus only bootstraps the user on first run                           |
-| `CMS_DATABASE_USER_NAME`     | The name for the CMS application's database user                                                            | TODO                                                                                                            |
-| `CMS_DATABASE_USER_PASSWORD` | The password for the CMS application's database user                                                        | TODO                                                                                                            |
-| `CMS_KEY`                    | The private token with which to make authenticated requests against the CMS                                 | **YES** - If changed, the admin user needs their token updated so the API can continue to authenticate          |
-| `CMS_SECRET`                 | Private secret used in encryption                                                                           | **NO**                                                                                                          |
-| `CMS_STORAGE_BUCKET`         | The name of the bucket for Terraform to create to store CMS assets - must not already be in use             | **NO** - Changing this will cause Terraform to attempt to destroy the old bucket and remove all existing assets |
+| Variable                     | Description                                                                                                 | Changeable                                                                                                |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `API_CREATOR_PASSPHRASE`     | The secret used to encrypt new Algorand account mnemonics so they can be (reasonably) safely stored at rest | ❌ Will prevent application from decrypting the mnemonics for the API-generated asset creator accounts    |
+| `API_DATABASE_USER_NAME`     | The name for the API application's database user                                                            | ❌ User must remain constant, since database tables are owned by (and only visible to) the original user  |
+| `API_DATABASE_USER_PASSWORD` | The password for the API application's database user                                                        | ✔️                                                                                                        |
+| `API_KEY`                    | For authentication with the API                                                                             | ✔️                                                                                                        |
+| `API_SECRET`                 | Private secret used in encryption                                                                           | ❌ Changing this will prevent the API from decrypting previously-encrypted data                           |
+| `CMS_ADMIN_EMAIL`            | The email address for the initial admin user created by Directus                                            | ❌ Changing has no effect, since Directus only bootstraps the user on first run                           |
+| `CMS_ADMIN_PASSWORD`         | The password for the initial admin user created by Directus                                                 | ❌ Changing has no effect, since Directus only bootstraps the user on first run                           |
+| `CMS_DATABASE_USER_NAME`     | The name for the CMS application's database user                                                            | ❌ User must remain constant, since database tables are owned by (and only visible to) the original user  |
+| `CMS_DATABASE_USER_PASSWORD` | The password for the CMS application's database user                                                        | ✔️                                                                                                        |
+| `CMS_KEY`                    | The private token with which to make authenticated requests against the CMS                                 | ✔️ If changed, the admin user needs their token updated so the API can continue to authenticate           |
+| `CMS_SECRET`                 | Private secret used in encryption                                                                           | ❌ Changing this will prevent the CMS from decrypting previously-encrypted data                           |
+| `CMS_STORAGE_BUCKET`         | The name of the bucket for Terraform to create to store CMS assets - must not already be in use             | ❌ Changing this will cause Terraform to attempt to destroy the old bucket and remove all existing assets |
 
 ## Optional
 

--- a/terraform/sample.terraform.tfvars
+++ b/terraform/sample.terraform.tfvars
@@ -5,7 +5,7 @@
 #
 # Otherwise, this file can be copied to `terraform.tfvars` & populated with values,
 # and terraform will load it automatically.
-algod_host                 = "algo.nfty.example.com"
+algod_host                 = "https://algo.nfty.example.com" # The `https://` protocol is necessary
 algod_key                  = "a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4"
 algod_port                 = "443"
 api_creator_passphrase     = "a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4"
@@ -33,46 +33,43 @@ sendgrid_from_email        = "admin@nfty.example.com"
 web_domain_mapping         = "nfty.example.com"
 web_image                  = "gcr.io/<gcp-project-id>/web:a1b2c3d4"
 
-# The GCP service account JSON needs to actually be read from the file;
-# this cannot just be the filename, and all properties MUST BE NEWLINE-DELIMITED.
+# Since Terraform disallows using `file(..)` in a .tfvars file,
+# it is easiest to store these in environment variables, eg:
+#
+#   export TF_VAR_credentials=$( cat <google-credentials>.json )
+#   export TF_VAR_web_firebase_service_account=$( cat <firebase-credentials>.json )
+#   export TF_VAR_web_next_public_firebase_config=$( cat <firebase-config>.json )
+#   terraform plan
+#
+# Additionally, the JSON from the Terraform-specific service account
+# (stored in `credentials`) **MUST BE** pretty-printed;
+# otherwise terraform cannot authenticate with gcloud
 
-# Example:
-#
-#   {
-#     "type": "service_account",
-#     "project_id": "<gcp-project-id>",
-#     "private_key_id": "ac4..snip...8ac",
-#     "private_key": "-----BEGIN PRIVATE KEY-----\nABC ... snip ... XYZ\n-----END PRIVATE KEY-----\n",
-#     "client_email": "<user>@<gcp-project-id>.iam.gserviceaccount.com",
-#     "client_id": "123... snip ...789",
-#     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-#     "token_uri": "https://oauth2.googleapis.com/token",
-#     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-#     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<user>%40<gcp-project-id>.iam.gserviceaccount.com"
-#   }
-credentials = file("gcp-service-account.json")
+credentials = '{
+  "type": "service_account",
+  "project_id": "<gcp-project-id>",
+  "private_key_id": "ac4..snip...8ac",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nABC ... snip ... XYZ\n-----END PRIVATE KEY-----\n",
+  "client_email": "<user>@<gcp-project-id>.iam.gserviceaccount.com",
+  "client_id": "123... snip ...789",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<user>%40<gcp-project-id>.iam.gserviceaccount.com"
+}'
 
-# These Firebase JSON values can be inlined or read from a file, and unlike the GCP
-# service account the properties DO NOT need to be newline-delimited.
-#
-# Example:
-#
-#   {
-#     "clientEmail": "<user>@<project>.iam.gserviceaccount.com",
-#     "privateKey": "-----BEGIN PRIVATE KEY-----\nABC... snip ...XYZ\n-----END PRIVATE KEY-----\n",
-#     "projectId": ""
-#   }
-web-firebase-service-account = file("firebase-service-account.json")
+web_firebase_service_account = '{
+  "clientEmail": "<user>@<project>.iam.gserviceaccount.com",
+  "privateKey": "-----BEGIN PRIVATE KEY-----\nABC... snip ...XYZ\n-----END PRIVATE KEY-----\n",
+  "projectId": ""
+}'
 
-# Example:
-#
-#   {
-#     "apiKey": "abc... snip ...xyz"
-#     "appId": "123... snip ...789",
-#     "authDomain": "auth.nfty.example.com",
-#     "measurementId": "A-ASDFQWERZX",
-#     "messagingSenderId": "1234567890",
-#     "projectId": "<project-id>",
-#     "storageBucket": "<bucket-name>"
-#   }
-web_next_public_firebase_config = file("firebase-config.json")
+web_next_public_firebase_config = '{
+  "apiKey": "abc... snip ...xyz"
+  "appId": "123... snip ...789",
+  "authDomain": "auth.nfty.example.com",
+  "measurementId": "A-ASDFQWERZX",
+  "messagingSenderId": "1234567890",
+  "projectId": "<project-id>",
+  "storageBucket": "<bucket-name>"
+}'


### PR DESCRIPTION
The documentation wasn't clear when `https://` was and was not necessary for various secrets and Terraform variables, which is really problematic because the node libraries that parse urls require 'https://' and the domain mappings must not. Additionally, there were several TODO items in one of the tables. This PR tries to clear all of tha tup.