### PR TITLE
[#67] Fix redeeming unminted assets

### DIFF
--- a/apps/web/src/clients/api-client.ts
+++ b/apps/web/src/clients/api-client.ts
@@ -65,7 +65,7 @@ export class ApiClient {
   constructor(
     readonly prefixUrl: string,
     readonly apiKey: string,
-    readonly defaultTimeout = 10_000
+    readonly defaultTimeout = 30_000
   ) {
     this.logger = logger.child({ context: 'ApiClient' })
     this.http = ky.create({

--- a/apps/web/src/components/modals/claim-nft-modal.tsx
+++ b/apps/web/src/components/modals/claim-nft-modal.tsx
@@ -53,7 +53,7 @@ export default function ClaimNFTModal({
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
-      setLoadingText(t('common:statuses.Verifying Passphrase'))
+      setLoadingText(t('common:statuses.Minting Asset'))
       setStatus('loading')
       try {
         const result = await onSubmit(passphrase, redeemCode)

--- a/services/api/src/modules/packs/packs.service.ts
+++ b/services/api/src/modules/packs/packs.service.ts
@@ -754,15 +754,6 @@ export default class PacksService {
 
     userInvariant(user, 'user not found', 404)
 
-    const collectibles = await this.collectibles.getCollectiblesByPackId(
-      pack.id
-    )
-    userInvariant(
-      collectibles.every((c) => c.address !== null),
-      'collectibles not yet minted for this pack',
-      404
-    )
-
     await PackModel.query(trx)
       .patch({
         claimedAt: new Date().toISOString(),


### PR DESCRIPTION
Closes #67 

Redeeming a pack with unminted assets will fail due to user invariant. This PR:

- Removes the invariant
- Updates the status text
- Increases `defaultTimeout` to 30s to minimize cancelled requests