### PR TITLE
[#69] Cookie consent prompt

### DIFF
--- a/apps/web/locales/en-US/common.json
+++ b/apps/web/locales/en-US/common.json
@@ -1,5 +1,6 @@
 {
   "actions": {
+    "Accept": "Accept",
     "Add Card": "Add Card",
     "Add New Payment Method": "Add New Payment Method",
     "Apply": "Apply",
@@ -68,6 +69,7 @@
     "s": "{{seconds}}s"
   },
   "global": {
+    "consent": "<0>We use cookies to collect information about your use of this site in order to enhance your experience on our website and to better understand your needs.</0><1>By clicking “Accept”, you agree to our <2>Terms of Use</2>, our <3>Privacy Policy</3> and our use of cookies on our site.</1>",
     "language": "English",
     "pageTitle": "Algorand Storefront",
     "pageDescription": "The best strorefront for all your NFT assets",
@@ -128,7 +130,8 @@
     },
     "legal": {
       "Community Guidelines": "Community Guidelines",
-      "Terms Of Service": "Terms Of Service",
+      "Privacy Policy": "Privacy Policy",
+      "Terms Of Use": "Terms Of Use",
       "copyright": "©2021 Algorand"
     }
   },

--- a/apps/web/src/components/cookie-consent/cookie-consent.module.css
+++ b/apps/web/src/components/cookie-consent/cookie-consent.module.css
@@ -1,0 +1,22 @@
+.root {
+  @apply fixed bottom-0 z-20 w-full bg-white shadow-large;
+}
+
+.wrapper {
+  @apply px-5 py-5 mx-auto text-center max-w-wrapper;
+  @apply justify-between md:flex md:items-center md:text-left;
+}
+
+.wrapper p {
+  @apply text-sm;
+}
+
+.wrapper p:first-child {
+  @apply mb-3;
+  @apply md:mr-5;
+}
+
+.acceptButton {
+  @apply mt-4;
+  @apply md:mt-0;
+}

--- a/apps/web/src/components/cookie-consent/cookie-consent.tsx
+++ b/apps/web/src/components/cookie-consent/cookie-consent.tsx
@@ -1,0 +1,48 @@
+import Trans from 'next-translate/Trans'
+import useTranslation from 'next-translate/useTranslation'
+import { useCallback, useState } from 'react'
+
+import css from './cookie-consent.module.css'
+
+import AppLink from '@/components/app-link/app-link'
+import Button from '@/components/button'
+import { getCookie, setCookie } from '@/utils/cookies-web'
+import { urls } from '@/utils/urls'
+
+const CONSENT_COOKIE = 'cookie-consent'
+
+export default function CookieConsent() {
+  const cookie = getCookie(CONSENT_COOKIE)
+  const [hasAccepted, setHasAccepted] = useState<boolean>(!!cookie)
+  const { t } = useTranslation()
+
+  const handleAccept = useCallback(() => {
+    setCookie(CONSENT_COOKIE, '1', 365)
+    setHasAccepted(true)
+  }, [])
+
+  if (hasAccepted) return null
+
+  return (
+    <div className={css.root}>
+      <div className={css.wrapper}>
+        <div>
+          <Trans
+            components={[
+              <p key={0} />,
+              <p key={1} />,
+              <AppLink key={2} href={urls.termsOfUse} />,
+              <AppLink key={3} href={urls.privacyPolicy} />,
+            ]}
+            i18nKey="common:global.consent"
+          />
+        </div>
+        <div className={css.acceptButton}>
+          <Button onClick={handleAccept} size="small" variant="primary">
+            {t('common:actions.Accept')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { SWRConfig } from 'swr'
 import '../styles/globals.css'
 
 import { Analytics } from '@/clients/firebase-analytics'
+import CookieConsent from '@/components/cookie-consent/cookie-consent'
 import { AuthProvider } from '@/contexts/auth-context'
 import { RedemptionProvider } from '@/contexts/redemption-context'
 import { fetcher } from '@/utils/swr'
@@ -35,6 +36,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       <RedemptionProvider>
         <AuthProvider>
           <Component {...pageProps} />
+          <CookieConsent />
         </AuthProvider>
       </RedemptionProvider>
     </SWRConfig>

--- a/apps/web/src/utils/navigation.ts
+++ b/apps/web/src/utils/navigation.ts
@@ -15,7 +15,10 @@ export const getSocialNavItems = (t: Translate) => [
 ]
 
 export const getLegalNavItems = (t: Translate) => [
-  { href: '#', label: t('common:nav.legal.Community Guidelines') },
-  { href: '#', label: t('common:nav.legal.Terms Of Service') },
+  {
+    href: urls.communityGuidelines,
+    label: t('common:nav.legal.Community Guidelines'),
+  },
+  { href: urls.termsOfUse, label: t('common:nav.legal.Terms Of Use') },
   { href: '', label: t('common:nav.legal.copyright') },
 ]

--- a/apps/web/src/utils/urls.ts
+++ b/apps/web/src/utils/urls.ts
@@ -24,6 +24,11 @@ export const urls = {
   profileShowcase: '/profile/:username',
   resetPassword: '/reset-password',
 
+  // Legal
+  communityGuidelines: '#',
+  privacyPolicy: '#',
+  termsOfUse: '#',
+
   api: {
     v1: {
       addToShowcase: '/api/v1/collection/add-showcase',


### PR DESCRIPTION
Closes #69 

To better comply with the wealth of emerging privacy laws, we should provide a consent notice that prompts the user to acknowledge the use of cookies on the website.

This PR adds a `<CookieConsent/>` component to `_app.tsx` that checks for a cookie named "cookie-consent". If present, it won't render the component. If not present, the prompt is displayed (uses some standard placeholder text and links to legal pages). These URLs will need to be provided by platform users.

<img width="1248" alt="Screen Shot 2021-11-15 at 6 13 42 PM" src="https://user-images.githubusercontent.com/658485/141868039-95282317-5c32-4b79-a4b6-6a7b68ad1200.png">

<img width="532" alt="Screen Shot 2021-11-15 at 6 13 50 PM" src="https://user-images.githubusercontent.com/658485/141868046-3db9f9bb-e87d-41d2-8b63-9ecb5cde9d12.png">
