### PR TITLE
[MISC] Pack Opening improvements & TS Node Fix

### DIFF
--- a/apps/web/locales/en-US/common.json
+++ b/apps/web/locales/en-US/common.json
@@ -45,6 +45,7 @@
     "Sign Out": "Sign Out",
     "Try Again": "Try Again",
     "View All Payment Methods": "View All Payment Methods",
+    "View In My Collection": "View In My Collection",
     "View My Collection": "View My Collection",
     "View On AlgoExplorer": "View on AlgoExplorer",
     "View Release": "View Release",

--- a/apps/web/src/components/pack-grid/pack-grid.module.css
+++ b/apps/web/src/components/pack-grid/pack-grid.module.css
@@ -4,17 +4,30 @@
 
 .gridWrapper {
   /* Base */
-  @apply grid grid-cols-2 gap-6 px-8 mt-8 justify-items-center;
+  @apply grid justify-center grid-cols-1 gap-6 px-8 mt-8 justify-items-center;
+  /* Mobile + */
+  @apply sm:grid-cols-2;
   /* Tablet + */
-  @apply md:gap-4 md:grid-cols-3 md:my-0 md:mx-auto md:max-w-4xl;
+  @apply md:grid-cols-3 md:gap-9 md:my-0 md:mx-auto md:max-w-wrapper;
+}
+
+.gridWrapper.double {
+  /* Mobile + */
+  @apply sm:grid-cols-2;
+  /* Tablet + */
+  @apply md:grid-cols-2;
+}
+
+.gridWrapper.single {
+  /* Mobile + */
+  @apply sm:grid-cols-1 sm:gap-0;
+  /* Tablet + */
+  @apply md:grid-cols-1 md:gap-0;
 }
 
 .gridItem {
-  @apply relative w-full h-72;
-  /* Tablet + */
-  @apply md:h-96 md:w-60;
+  @apply relative w-full max-w-700;
 }
-
 .gridItemEmpty {
   /* Base */
   @apply hidden;

--- a/apps/web/src/components/pack-grid/pack-grid.module.css
+++ b/apps/web/src/components/pack-grid/pack-grid.module.css
@@ -28,6 +28,7 @@
 .gridItem {
   @apply relative w-full max-w-700;
 }
+
 .gridItemEmpty {
   /* Base */
   @apply hidden;
@@ -53,5 +54,9 @@
 }
 
 .placeholderWrapper {
-  @apply h-full opacity-100;
+  @apply absolute top-0 w-full h-full opacity-100;
+}
+
+.viewCollectionButton {
+  @apply relative block mx-auto my-12;
 }

--- a/apps/web/src/components/pack-grid/pack-grid.tsx
+++ b/apps/web/src/components/pack-grid/pack-grid.tsx
@@ -64,7 +64,12 @@ export default function PackGrid({
           </Button>
         </div>
       )}
-      <ul className={css.gridWrapper}>
+      <ul
+        className={clsx(css.gridWrapper, {
+          [css.single]: packCards.length === 1,
+          [css.double]: packCards.length === 2,
+        })}
+      >
         {animationIn.map((style, index) => {
           return (
             <animated.li

--- a/apps/web/src/components/pack-grid/pack-grid.tsx
+++ b/apps/web/src/components/pack-grid/pack-grid.tsx
@@ -1,6 +1,7 @@
 import { PackWithCollectibles } from '@algomart/schemas'
 import { animated, config, useTrail } from '@react-spring/web'
 import clsx from 'clsx'
+import { useRouter } from 'next/router'
 import useTranslation from 'next-translate/useTranslation'
 import { useState } from 'react'
 
@@ -9,6 +10,7 @@ import css from './pack-grid.module.css'
 import Button from '@/components/button'
 import PackItem from '@/components/pack-grid/pack-item'
 import PackPlaceholder from '@/components/pack-grid/pack-placeholder'
+import { urls } from '@/utils/urls'
 
 export interface PackGridProps {
   packCards: PackWithCollectibles['collectibles']
@@ -21,18 +23,19 @@ export default function PackGrid({
   packTitle,
   transitionStyle = 'automatic',
 }: PackGridProps) {
+  const { push } = useRouter()
   const { t } = useTranslation()
 
   // Automatic animations
   const animationIn = useTrail(packCards.length, {
     config: config.gentle,
-    delay: 3000,
+    delay: 2500,
     from: { opacity: 0, y: -50 },
     to: { opacity: 1, y: 0 },
   })
   const animationOpacity = useTrail(packCards.length, {
-    config: config.molasses,
-    delay: 1000,
+    config: config.default,
+    delay: 5000,
     from: { opacity: 0 },
     to: { opacity: 1 },
   })
@@ -82,7 +85,7 @@ export default function PackGrid({
                 color={packCards[index]?.rarity?.color}
                 imageSource={packCards[index].image}
                 labelName={packCards[index]?.rarity?.name}
-                title={packCards[index].title}
+                title={`${packCards[index].title}`}
               />
               <animated.div
                 className={clsx(css.placeholderWrapper, {
@@ -102,6 +105,7 @@ export default function PackGrid({
                 }
               >
                 <PackPlaceholder
+                  hideContent={packCards.length < 3}
                   index={index}
                   key={packCards[index].id}
                   collectibleEdition={`#${packCards[index].edition}`}
@@ -114,6 +118,12 @@ export default function PackGrid({
           )
         })}
       </ul>
+      <Button
+        className={css.viewCollectionButton}
+        onClick={() => push(urls.myCollectibles)}
+      >
+        {t('common:actions.View In My Collection')}
+      </Button>
     </>
   )
 }

--- a/apps/web/src/components/pack-grid/pack-item.module.css
+++ b/apps/web/src/components/pack-grid/pack-item.module.css
@@ -1,5 +1,5 @@
 .root {
-  @apply absolute w-full h-full p-0 duration-300 bg-white border rounded-md opacity-100 border-base-gray-border shadow-medium;
+  @apply relative w-full h-full p-0 duration-300 bg-white border rounded-md opacity-100 border-base-gray-border shadow-medium;
 }
 
 .column {
@@ -8,13 +8,6 @@
 
 .placeholder {
   @apply inline-flex justify-center w-full m-auto;
-}
-
-.imageWrapper {
-  /* Base + */
-  @apply flex flex-col bg-black max-h-40 h-1/2;
-  /* Tablet + */
-  @apply md:max-h-60 md:h-full;
 }
 
 .image {
@@ -30,23 +23,27 @@
 }
 
 .informationWrapper {
-  @apply text-center bg-white rounded-b-sm h-1/2;
+  @apply text-center bg-white rounded-sm;
 }
 
 .information {
   /* Base + */
-  @apply bg-white px-2.5 flex flex-col items-center justify-center;
+  @apply flex flex-col items-center justify-center pb-5;
+}
+
+.titleWrapper {
+  @apply flex items-center justify-center w-full p-3;
 }
 
 .title {
   /* Base + */
-  @apply pt-1 text-sm font-bold text-base-gray-text line-clamp-2;
+  @apply h-full pt-1 text-sm font-bold text-base-gray-text line-clamp-2;
   /* Tablet + */
   @apply md:text-base md:pt-3;
 }
 
 .label {
-  @apply px-4 py-2 mt-3 text-xs text-white uppercase rounded-full bg-base-gray-border;
+  @apply px-4 py-2 text-xs text-white uppercase rounded-full bg-base-gray-border;
 }
 
 .icon {

--- a/apps/web/src/components/pack-grid/pack-item.module.css
+++ b/apps/web/src/components/pack-grid/pack-item.module.css
@@ -1,5 +1,5 @@
 .root {
-  @apply absolute bg-white duration-300 border-base-gray-border border opacity-100 p-0 rounded-md shadow-medium h-full w-full;
+  @apply absolute w-full h-full p-0 duration-300 bg-white border rounded-md opacity-100 border-base-gray-border shadow-medium;
 }
 
 .column {
@@ -7,12 +7,12 @@
 }
 
 .placeholder {
-  @apply inline-flex m-auto justify-center w-full;
+  @apply inline-flex justify-center w-full m-auto;
 }
 
 .imageWrapper {
   /* Base + */
-  @apply flex flex-col max-h-40 h-1/2 bg-black;
+  @apply flex flex-col bg-black max-h-40 h-1/2;
   /* Tablet + */
   @apply md:max-h-60 md:h-full;
 }
@@ -26,11 +26,11 @@
 }
 
 .calloutWrapper {
-  @apply line-clamp-2 p-2 text-center text-white text-xs w-full;
+  @apply w-full p-2 text-xs text-center text-white line-clamp-2;
 }
 
 .informationWrapper {
-  @apply bg-white h-1/2 text-center rounded-b-sm;
+  @apply text-center bg-white rounded-b-sm h-1/2;
 }
 
 .information {
@@ -40,13 +40,13 @@
 
 .title {
   /* Base + */
-  @apply text-base-gray-text pt-1 line-clamp-2 font-bold text-sm;
+  @apply pt-1 text-sm font-bold text-base-gray-text line-clamp-2;
   /* Tablet + */
   @apply md:text-base md:pt-3;
 }
 
 .label {
-  @apply text-white text-xs bg-base-gray-border rounded-full px-4 py-2 mt-3 uppercase;
+  @apply px-4 py-2 mt-3 text-xs text-white uppercase rounded-full bg-base-gray-border;
 }
 
 .icon {

--- a/apps/web/src/components/pack-grid/pack-item.tsx
+++ b/apps/web/src/components/pack-grid/pack-item.tsx
@@ -24,6 +24,7 @@ export default function PackItem({
 }: PackItemProps) {
   const { t } = useTranslation('common')
   const label = labelName || t('common:global.rarityDefault')
+
   return (
     <div className={css.root}>
       <div className={css.column}>

--- a/apps/web/src/components/pack-grid/pack-item.tsx
+++ b/apps/web/src/components/pack-grid/pack-item.tsx
@@ -55,11 +55,13 @@ export default function PackItem({
             </div>
           )}
           <div className={css.information}>
-            <h1 className={css.title}>{title}</h1>
+            <div className={css.titleWrapper}>
+              <h2 className={css.title}>{title}</h2>
+            </div>
+
             <span
               className={clsx(css.label, {
                 [css.defaultColor]: !color,
-                backgroundColor: color,
               })}
               style={{ backgroundColor: color }}
             >

--- a/apps/web/src/components/pack-grid/pack-placeholder.module.css
+++ b/apps/web/src/components/pack-grid/pack-placeholder.module.css
@@ -1,6 +1,10 @@
 .root {
-  @apply absolute bg-cover bg-pack-texture overflow-hidden h-full p-5 relative text-center;
+  @apply absolute top-0 w-full h-full p-5 overflow-hidden text-center bg-cover bg-pack-texture;
   background-size: 200%;
+}
+
+.root.hideContent {
+  @apply flex items-center justify-center;
 }
 
 .backgroundPosition-0 {
@@ -24,25 +28,25 @@
 
 .questionMark {
   /* Base + */
-  @apply font-bold h-40 pb-5 text-white;
+  @apply h-40 pb-5 font-bold text-white;
   font-size: 120px;
   /* Tablet + */
   @apply md:h-60;
 }
 
 .packName {
-  @apply bg-white font-bold mb-1 p-3 rounded-sm text-sm;
+  @apply p-3 mb-1 text-sm font-bold bg-white rounded-sm;
   border-bottom-left-radius: 0px;
   border-bottom-right-radius: 0px;
   mix-blend-mode: screen;
 }
 
 .infoWrapper {
-  @apply flex font-bold justify-between items-center text-xs;
+  @apply flex items-center justify-between text-xs font-bold;
 }
 
 .infoWrapperColumn {
-  @apply bg-white py-2 rounded-sm w-1/2;
+  @apply w-1/2 py-2 bg-white rounded-sm;
   mix-blend-mode: screen;
 }
 

--- a/apps/web/src/components/pack-grid/pack-placeholder.tsx
+++ b/apps/web/src/components/pack-grid/pack-placeholder.tsx
@@ -3,34 +3,44 @@ import useTranslation from 'next-translate/useTranslation'
 
 import css from './pack-placeholder.module.css'
 export interface PackPlaceholderProps {
-  index: number
   collectibleEdition: string
+  hideContent?: boolean
+  index: number
   packItemNumber: number
   packTitle: string
   packTotalCount: number
 }
 export default function PackPlaceholder({
-  index,
+  hideContent,
   collectibleEdition,
-  packTitle,
+  index,
   packItemNumber,
+  packTitle,
   packTotalCount,
 }: PackPlaceholderProps) {
   const { t } = useTranslation()
   return (
     <div
-      className={clsx(css.root, css[`backgroundPosition-${(index + 1) % 6}`])}
+      className={clsx(css.root, css[`backgroundPosition-${(index + 1) % 6}`], {
+        [css.hideContent]: hideContent,
+      })}
     >
       <div className={css.questionMark}>?</div>
-      <div className={css.packName}>{packTitle}</div>
-      <div className={css.infoWrapper}>
-        <div className={clsx(css.infoWrapperColumn, css.infoWrapperLeft)}>
-          {collectibleEdition}
-        </div>
-        <div className={clsx(css.infoWrapperColumn, css.infoWrapperRight)}>
-          {`${packItemNumber} ${t('collection:viewer.of')} ${packTotalCount}`}
-        </div>
-      </div>
+      {!hideContent && (
+        <>
+          <div className={css.packName}>{packTitle}</div>
+          <div className={css.infoWrapper}>
+            <div className={clsx(css.infoWrapperColumn, css.infoWrapperLeft)}>
+              {collectibleEdition}
+            </div>
+            <div className={clsx(css.infoWrapperColumn, css.infoWrapperRight)}>
+              {`${packItemNumber} ${t(
+                'collection:viewer.of'
+              )} ${packTotalCount}`}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3074,6 +3074,27 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-9.1.0.tgz",
       "integrity": "sha512-llLJZ8OAlZrjGlBvamm6Zdo/HmGAcCLq5gx7cSwUX8No+n/8ip+oaC4x33IdZIif8+Rh5dQUIZXmfbSghiOmNQ=="
     },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@cypress/request": {
       "version": "2.88.7",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.7.tgz",
@@ -6501,10 +6522,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
       "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "node_modules/@types/aria-query": {
@@ -30408,6 +30447,7 @@
         "rosie": "2.1.0",
         "sqlite3": "5.0.2",
         "testdouble": "3.16.3",
+        "ts-node": "10.4.0",
         "ts-node-dev": "1.1.8",
         "tsconfig-paths": "3.11.0",
         "typescript": "4.4.4"
@@ -30415,6 +30455,27 @@
       "engines": {
         "node": ">=16",
         "npm": ">=7"
+      }
+    },
+    "services/api/node_modules/acorn": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "services/api/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "services/api/node_modules/ajv": {
@@ -30432,10 +30493,57 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "services/api/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "services/api/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "services/api/node_modules/ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
     }
   },
   "dependencies": {
@@ -30483,12 +30591,25 @@
         "sqlite3": "5.0.2",
         "testdouble": "3.16.3",
         "toad-scheduler": "1.6.0",
+        "ts-node": "10.4.0",
         "ts-node-dev": "1.1.8",
         "tsconfig-paths": "3.11.0",
         "typescript": "4.4.4",
         "uuid": "8.3.2"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        },
         "ajv": {
           "version": "8.8.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.0.tgz",
@@ -30500,10 +30621,36 @@
             "uri-js": "^4.2.2"
           }
         },
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+          "dev": true
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "ts-node": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+          "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+          "dev": true,
+          "requires": {
+            "@cspotcode/source-map-support": "0.7.0",
+            "@tsconfig/node10": "^1.0.7",
+            "@tsconfig/node12": "^1.0.7",
+            "@tsconfig/node14": "^1.0.0",
+            "@tsconfig/node16": "^1.0.2",
+            "acorn": "^8.4.1",
+            "acorn-walk": "^8.1.1",
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "yn": "3.1.1"
+          }
         }
       }
     },
@@ -32761,6 +32908,21 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-9.1.0.tgz",
       "integrity": "sha512-llLJZ8OAlZrjGlBvamm6Zdo/HmGAcCLq5gx7cSwUX8No+n/8ip+oaC4x33IdZIif8+Rh5dQUIZXmfbSghiOmNQ=="
+    },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
     },
     "@cypress/request": {
       "version": "2.88.7",
@@ -35437,10 +35599,28 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "devOptional": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
     "@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
       "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "@types/aria-query": {

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -17,7 +17,7 @@
     "dev": "tsnd -r tsconfig-paths/register -r dotenv/config --quiet src/index.ts",
     "start": "node -r dotenv/config dist/index.js",
     "test": "jest",
-    "knex": "node --require dotenv/config --require tsconfig-paths/register ../../node_modules/.bin/knex --knexfile ./src/configuration/knex-config.ts",
+    "knex": "ts-node --require dotenv/config --require tsconfig-paths/register ../../node_modules/.bin/knex --knexfile ./src/configuration/knex-config.ts",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
@@ -32,6 +32,7 @@
     "sqlite3": "5.0.2",
     "testdouble": "3.16.3",
     "ts-node-dev": "1.1.8",
+    "ts-node": "10.4.0",
     "tsconfig-paths": "3.11.0",
     "typescript": "4.4.4"
   },


### PR DESCRIPTION
## Overview:
- Adjust layouts of revealed cards in pack so that if there's one or two, they're prominently centered. If there's more, it defaults to the grid layout. Also adjusts some of the styles in the cards so the sizes aren't stretched undesirably.
- Adds `hideContent` prop to pack grid. When true, it only shows the question mark, and not the pack metadata, which is arguably only relevant in packs that have many cards. Right now, this shows content if there are 3 or more.
- Also added the "View In My Collection" button from the designs.
- Ran into an issue in DRL implementation (which uses some more up-to-date packages) where the API's knex migrations will fail since they're triggered using the node binary. This PR adds TS Node to ensure it compiles.

## Screenshots:
![screencapture-localhost-3000-pack-opening-ec05b818-e631-4fa9-9dbe-ad9f888a3161-2021-11-18-14_23_55](https://user-images.githubusercontent.com/658485/142484361-287a4837-397e-44cf-9127-6d100f7585d9.png)

![screencapture-localhost-3000-pack-opening-ec05b818-e631-4fa9-9dbe-ad9f888a3161-2021-11-18-14_24_57](https://user-images.githubusercontent.com/658485/142484376-4e6ae8c3-cfe0-4047-a6b9-f6450fac0daf.png)

![screencapture-localhost-3000-pack-opening-ec05b818-e631-4fa9-9dbe-ad9f888a3161-2021-11-18-14_25_35](https://user-images.githubusercontent.com/658485/142484383-519ad64e-c72d-440a-a45c-ec8108d3852d.png)

