### PR TITLE
Update documentation with note about system dependencies for M1 Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Install all dependencies (may take a while the first time):
 npm install
 ```
 
+> ### For M1 Mac Users
+> You might need to manually install additional system dependencies using [Homebrew](https://brew.sh/) before running `npm install`. Once Homebrew is installed, run 
+> ```bash
+> brew install pkg-config cairo pango libpng jpeg giflib librsvg
+> ```
+
 Additional setup may be required within each package. Check the README in each for more details. Once everything is configured, you can start everything in development/watch mode:
 
 ```bash


### PR DESCRIPTION
Ran into this issue on a separate Algomart project where an issue installing dependencies for `node-canvas` came up. https://github.com/Automattic/node-canvas/issues/1733#issuecomment-762659473

If these weren't manually installed, running `npm install` would generate a bunch of `node-gyp` errors. 