### PR TITLE
[#76] Task for checking wire transfers

### DIFF
--- a/apps/cms/.env.example
+++ b/apps/cms/.env.example
@@ -5,8 +5,6 @@ PORT=8055
 PUBLIC_URL="http://localhost:8055"
 # Quieter logs (see: https://docs.directus.io/reference/environment-variables/#general )
 # LOG_LEVEL="warn"
-# Currency for application. Make sure this matches the api and web packages.
-CURRENCY=
 
 ####################################################################################################
 ## Database

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -8,7 +8,7 @@ NEXT_PUBLIC_3JS_DEBUG=
 API_URL=
 API_KEY=
 
-# Currency for application. Make sure this matches the cms and api packages.
+# Currency for application - needs to match the api env file and the CMS currency field.
 CURRENCY=
 
 # Firebase

--- a/apps/web/src/components/bank-account-form/sections/bank-account-success.tsx
+++ b/apps/web/src/components/bank-account-form/sections/bank-account-success.tsx
@@ -4,6 +4,7 @@ import {
   PublishedPack,
 } from '@algomart/schemas'
 import { CheckCircleIcon } from '@heroicons/react/outline'
+import { useRouter } from 'next/router'
 import useTranslation from 'next-translate/useTranslation'
 import { useCallback } from 'react'
 
@@ -24,17 +25,15 @@ export default function BankAccountSuccess({
   release,
 }: BankAccountSuccessProps) {
   const { t } = useTranslation()
-
+  const router = useRouter()
   const isActiveAuction =
     release.type === PackType.Auction &&
     isAfterNow(new Date(release.auctionUntil as string))
 
   const handleReturnToListing = useCallback(() => {
     const path = urls.release.replace(':packSlug', release.slug)
-    if (typeof window !== 'undefined') {
-      window.location.assign(new URL(path, window.location.origin).href)
-    }
-  }, [release.slug])
+    router.push(path)
+  }, [release.slug, router])
 
   return (
     <div className={css.root}>

--- a/apps/web/src/contexts/payment-context.tsx
+++ b/apps/web/src/contexts/payment-context.tsx
@@ -28,7 +28,7 @@ import collectibleService from '@/services/collectible-service'
 import { getExpirationDate } from '@/utils/date-time'
 import { encryptCardDetails } from '@/utils/encryption'
 import { toJSON } from '@/utils/form-to-json'
-import { formatFloatToInt, isGreaterThanOrEqual } from '@/utils/format-currency'
+import { formatFloatToInt, isGreaterThan } from '@/utils/format-currency'
 import { poll } from '@/utils/poll'
 import {
   maximumBidForCardPayments,
@@ -466,7 +466,7 @@ export function usePaymentProvider({
         if (
           !Environment.isWireEnabled ||
           (Environment.isWireEnabled &&
-            !isGreaterThanOrEqual(bid, maximumBidForCardPayments))
+            !isGreaterThan(bid, maximumBidForCardPayments))
         ) {
           setLoadingText(t('common:statuses.Authorizing card'))
 

--- a/packages/schemas/src/payments.ts
+++ b/packages/schemas/src/payments.ts
@@ -172,6 +172,7 @@ const ToPaymentCardBaseSchema = Type.Object({
 const ToPaymentBaseSchema = Type.Object({
   externalId: Type.String({ format: 'uuid' }),
   status: Type.Optional(Type.Enum(PaymentStatus)),
+  sourceId: Type.String({ format: 'uuid' }),
   error: Type.Optional(Type.Enum(CirclePaymentErrorCode)),
 })
 

--- a/packages/schemas/src/payments.ts
+++ b/packages/schemas/src/payments.ts
@@ -172,8 +172,9 @@ const ToPaymentCardBaseSchema = Type.Object({
 const ToPaymentBaseSchema = Type.Object({
   externalId: Type.String({ format: 'uuid' }),
   status: Type.Optional(Type.Enum(PaymentStatus)),
-  sourceId: Type.String({ format: 'uuid' }),
   error: Type.Optional(Type.Enum(CirclePaymentErrorCode)),
+  amount: Type.String(),
+  sourceId: Type.String({ format: 'uuid' }),
 })
 
 const PaymentBaseSchema = Type.Object({

--- a/packages/schemas/src/payments.ts
+++ b/packages/schemas/src/payments.ts
@@ -468,6 +468,7 @@ export const GetPaymentCardStatusSchema = Type.Object({
 export const PaymentSchema = Type.Intersect([
   BaseSchema,
   PaymentBaseSchema,
+  Type.Omit(ToPaymentBaseSchema, ['externalId', 'amount', 'sourceId']),
   Type.Object({
     externalId: Nullable(Type.String({ format: 'uuid' })),
   }),

--- a/packages/schemas/src/payments.ts
+++ b/packages/schemas/src/payments.ts
@@ -468,7 +468,6 @@ export const GetPaymentCardStatusSchema = Type.Object({
 export const PaymentSchema = Type.Intersect([
   BaseSchema,
   PaymentBaseSchema,
-  Type.Omit(ToPaymentBaseSchema, ['externalId']),
   Type.Object({
     externalId: Nullable(Type.String({ format: 'uuid' })),
   }),

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -51,7 +51,7 @@ SECRET=
 # Used to generate blockchain assets
 CREATOR_PASSPHRASE=
 
-# Currency for application. Make sure this matches the cms and web packages.
+# Currency for application - needs to match the web env file and the CMS currency field.
 CURRENCY=
 
 # Coinbase API details (for currency conversion)

--- a/services/api/src/lib/circle-adapter.ts
+++ b/services/api/src/lib/circle-adapter.ts
@@ -138,6 +138,7 @@ function toPaymentStatus(
 function toPaymentBase(response: CirclePaymentResponse): ToPaymentBase {
   return {
     externalId: response.id,
+    amount: response.amount.amount,
     sourceId: response.source.id,
     status: toPaymentStatus(response.status, response.verification),
     error: response.errorCode,
@@ -238,7 +239,6 @@ export default class CircleAdapter {
     const response = await this.http
       .get(`v1/banks/wires/${id}/instructions`)
       .json<CircleResponse<GetPaymentBankAccountInstructions>>()
-    console.log('getPaymentBankAccountInstructionsById resp:', response)
 
     if (isCircleSuccessResponse(response)) {
       return response.data

--- a/services/api/src/lib/circle-adapter.ts
+++ b/services/api/src/lib/circle-adapter.ts
@@ -210,12 +210,6 @@ export default class CircleAdapter {
     return null
   }
 
-  async toPaymentBase(
-    request: CirclePaymentResponse
-  ): Promise<ToPaymentBase | null> {
-    return toPaymentBase(request)
-  }
-
   async createPayment(
     request: CircleCreatePayment
   ): Promise<ToPaymentBase | null> {

--- a/services/api/src/lib/circle-adapter.ts
+++ b/services/api/src/lib/circle-adapter.ts
@@ -238,6 +238,7 @@ export default class CircleAdapter {
     const response = await this.http
       .get(`v1/banks/wires/${id}/instructions`)
       .json<CircleResponse<GetPaymentBankAccountInstructions>>()
+    console.log('getPaymentBankAccountInstructionsById resp:', response)
 
     if (isCircleSuccessResponse(response)) {
       return response.data

--- a/services/api/src/lib/circle-adapter.ts
+++ b/services/api/src/lib/circle-adapter.ts
@@ -138,6 +138,7 @@ function toPaymentStatus(
 function toPaymentBase(response: CirclePaymentResponse): ToPaymentBase {
   return {
     externalId: response.id,
+    sourceId: response.source.id,
     status: toPaymentStatus(response.status, response.verification),
     error: response.errorCode,
   }
@@ -292,7 +293,7 @@ export default class CircleAdapter {
 
   async getPayments(
     query: CirclePaymentQuery
-  ): Promise<CirclePaymentResponse[] | null> {
+  ): Promise<ToPaymentBase[] | null> {
     const searchParams = new URLSearchParams()
     for (const [key, value] of Object.entries(query)) {
       searchParams.append(key, `${value}`)
@@ -302,7 +303,7 @@ export default class CircleAdapter {
       .json<CircleResponse<CirclePaymentResponse[]>>()
 
     if (isCircleSuccessResponse(response)) {
-      return response.data
+      return response.data.map((payment) => toPaymentBase(payment))
     }
 
     this.logger.error({ response }, 'Failed to get payments')

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -463,12 +463,12 @@ export default class PaymentsService {
 
   async getWirePayment(sourceId: string): Promise<ToPaymentBase | null> {
     // Last 24 hours
-    const newDate24HoursInpast = new Date(
-      new Date().setDate(new Date().getDate() + 1)
-    )
+    const newDate24HoursInPast = new Date(
+      new Date().setDate(new Date().getDate() - 1)
+    ).toISOString()
     // Get recent payments of wire type
     const payments = await this.circle.getPayments({
-      from: newDate24HoursInpast.toString(),
+      from: newDate24HoursInPast.toString(),
       type: CirclePaymentQueryType.wire,
     })
     if (!payments) return null
@@ -638,6 +638,7 @@ export default class PaymentsService {
         const circleBankAccount = await this.circle.getPaymentBankAccountById(
           bank.externalId
         )
+        console.log('circleBankAccount:', circleBankAccount)
         invariant(
           circleBankAccount,
           `external bank account ${bank.externalId} not found`

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -589,7 +589,8 @@ export default class PaymentsService {
 
     await Promise.all(
       pendingPayments.map(async (payment) => {
-        if (payment.externalId) {
+        // Card flow
+        if (payment.externalId && payment.paymentCardId) {
           const circlePayment = await this.circle.getPaymentById(
             payment.externalId
           )
@@ -605,6 +606,7 @@ export default class PaymentsService {
             updatedPayments++
           }
         }
+        // Wire transfer flow
         if (payment.paymentBankId && !payment.externalId) {
           const wirePayment = await this.getWirePayment(payment.paymentBankId)
           if (wirePayment) {

--- a/services/api/src/modules/payments/payments.service.ts
+++ b/services/api/src/modules/payments/payments.service.ts
@@ -494,7 +494,8 @@ export default class PaymentsService {
       invariant(amount !== null, 'unable to convert to currency')
       const amountInt = formatFloatToInt(amount)
       return (
-        payment.sourceId === sourceId && amountInt === foundBankAccount.amount
+        payment.sourceId === foundBankAccount.externalId &&
+        amountInt === foundBankAccount.amount
       )
     })
     if (!sourcePayment) return null
@@ -629,7 +630,7 @@ export default class PaymentsService {
           }
         }
         // Wire transfer flow
-        if (payment.paymentBankId && !payment.externalId) {
+        else if (payment.paymentBankId) {
           const wirePayment = await this.getWirePayment(payment.paymentBankId)
           if (wirePayment) {
             await PaymentModel.query(trx).patchAndFetchById(payment.id, {

--- a/services/api/src/tasks/index.ts
+++ b/services/api/src/tasks/index.ts
@@ -7,6 +7,7 @@ import generateCollectiblesTask from './generate-collectibles.task'
 import generatePacksTask from './generate-packs.task'
 import handlePackAuctionCompletionTask from './handle-pack-auction-completion.task'
 import handlePackAuctionExpirationTask from './handle-pack-auction-expiration.task'
+import { updatePaymentBankStatusesTask } from './update-payment-bank-statuses.task'
 import { updatePaymentCardStatusesTask } from './update-payment-card-statuses.task'
 import { updatePaymentStatusesTask } from './update-payment-statuses.task'
 
@@ -84,6 +85,17 @@ export function configureTasks(app: FastifyInstance) {
   //#endregion
 
   //#region Circle Payments
+  app.scheduler.addSimpleIntervalJob(
+    new SimpleIntervalJob(
+      { seconds: 10 },
+      new AsyncTask(
+        'check-pending-banks',
+        async () => await updatePaymentBankStatusesTask(app.container),
+        (error) => app.log.error(error)
+      )
+    )
+  )
+
   app.scheduler.addSimpleIntervalJob(
     new SimpleIntervalJob(
       { seconds: 10 },

--- a/services/api/src/tasks/index.ts
+++ b/services/api/src/tasks/index.ts
@@ -87,7 +87,7 @@ export function configureTasks(app: FastifyInstance) {
   //#region Circle Payments
   app.scheduler.addSimpleIntervalJob(
     new SimpleIntervalJob(
-      { seconds: 10 },
+      { minutes: 1 },
       new AsyncTask(
         'check-pending-banks',
         async () => await updatePaymentBankStatusesTask(app.container),

--- a/services/api/src/tasks/update-payment-bank-statuses.task.ts
+++ b/services/api/src/tasks/update-payment-bank-statuses.task.ts
@@ -1,0 +1,21 @@
+import { Model } from 'objection'
+
+import PaymentsService from '@/modules/payments/payments.service'
+import DependencyResolver from '@/shared/dependency-resolver'
+import { logger } from '@/utils/logger'
+
+export async function updatePaymentBankStatusesTask(
+  registry: DependencyResolver
+) {
+  const log = logger.child({ task: 'update-payment-bank-statuses' })
+  const payments = registry.get<PaymentsService>(PaymentsService.name)
+  const trx = await Model.startTransaction()
+  try {
+    const updatedCards = await payments.updatePaymentBankStatuses(trx)
+    log.info('updated %d payment bank account statuses', updatedCards)
+    await trx.commit()
+  } catch (error) {
+    await trx.rollback()
+    log.error(error as Error, 'failed to update payment bank account statuses')
+  }
+}

--- a/services/api/src/tasks/update-payment-bank-statuses.task.ts
+++ b/services/api/src/tasks/update-payment-bank-statuses.task.ts
@@ -11,8 +11,8 @@ export async function updatePaymentBankStatusesTask(
   const payments = registry.get<PaymentsService>(PaymentsService.name)
   const trx = await Model.startTransaction()
   try {
-    const updatedCards = await payments.updatePaymentBankStatuses(trx)
-    log.info('updated %d payment bank account statuses', updatedCards)
+    const updatedBanks = await payments.updatePaymentBankStatuses(trx)
+    log.info('updated %d payment bank account statuses', updatedBanks)
     await trx.commit()
   } catch (error) {
     await trx.rollback()

--- a/services/api/src/utils/format-currency.ts
+++ b/services/api/src/utils/format-currency.ts
@@ -63,13 +63,14 @@ function getAmountAndScale(exchangeRate: string) {
 }
 
 export function convertFromUSD(
-  usdAmount: string | number,
+  usdFloat: string | number,
   rateForNonUSD: { [key: string]: string }
 ) {
   if (!rateForNonUSD[currency.code]) return null
   const rates = { [currency.code]: getAmountAndScale(rateForNonUSD.USD) }
-  const amount =
-    typeof usdAmount === 'string' ? Number.parseFloat(usdAmount) : usdAmount
+  const usdFloatNumber =
+    typeof usdFloat === 'string' ? Number.parseFloat(usdFloat) : usdFloat
+  const amount = formatFloatToInt(usdFloatNumber)
   const price = dinero({ amount, currency: USD })
   const finalPrice = currency === USD ? price : convert(price, currency, rates)
   const float = toFormat(finalPrice, ({ amount, currency }) =>

--- a/services/api/src/utils/format-currency.ts
+++ b/services/api/src/utils/format-currency.ts
@@ -12,9 +12,10 @@ import { Configuration } from '@/configuration'
 
 export const currency = Configuration.currency
 
-export function formatFloatToInt(float: number) {
+export function formatFloatToInt(float: number | string) {
+  const number = typeof float === 'string' ? Number.parseFloat(float) : float
   const factor = currency.base ** currency.exponent
-  const amount = Math.round(float * factor)
+  const amount = Math.round(number * factor)
   const price = dinero({ amount, currency })
   return price.toJSON().amount
 }
@@ -62,11 +63,13 @@ function getAmountAndScale(exchangeRate: string) {
 }
 
 export function convertFromUSD(
-  amount: number,
+  usdAmount: string | number,
   rateForNonUSD: { [key: string]: string }
 ) {
   if (!rateForNonUSD[currency.code]) return null
   const rates = { [currency.code]: getAmountAndScale(rateForNonUSD.USD) }
+  const amount =
+    typeof usdAmount === 'string' ? Number.parseFloat(usdAmount) : usdAmount
   const price = dinero({ amount, currency: USD })
   const finalPrice = currency === USD ? price : convert(price, currency, rates)
   const float = toFormat(finalPrice, ({ amount, currency }) =>


### PR DESCRIPTION
### Changes
- Scheduled task for updating wire payment method statuses
- Adding to the payment statuses task to support checking for wire transfers

Closes #76

### Testing
- In the web's env file, set `NEXT_PUBLIC_WIRE_PAYMENT_ENABLED` to `true`
- Create a purchase or auction type pack in the CMS with a price higher than 3000 (assuming USD is the currency used for web/api)
- Purchase pack and save wire details (or keep page open to reference)
- Mock wire transfer using [this endpoint](https://developers.circle.com/reference#payments-payments-mock-create); the `trackingRef` will match the `trackingRef` in the response (or Tracking Reference in the UI).

### Considerations
We are looking at payments within the past 24 hours, since we have to get all wire transfer payments and check for a matching source ID. Since an amount is not specified when creating a wire account using Circle's API and there's no payment record in Circle until its initiated by the user, the user _could_ send a wrong amount and this task would not be aware of this. Or perhaps if there was 2 wire payments done to correct the amount, it would not pick up on this either. 

Due to this, there should always be a way for a customer to contact customer support in the event something like this happened. Also, there at some point likely should be a way to aid customer support in verifying this. Though this wouldn't be straightforward, as the user could have made other wire payments using the same bank account, at least if we're planning to support reusing a bank account for a payment, which I'm assuming we will be. So maybe a manual option to award them the pack and a dashboard with all payments in Circle's API associated with that bank account, as well as a list of packs they've purchased. 

### To-do
Possible to-do to discuss: Not removing the claim on failure, but instead sending an email to the user and adding an expiration date to the payment + a task that looks for expired dates and removes a claim. 
