### PR TITLE
Downgrade Directus to 9.0.1

### DIFF
--- a/apps/cms/extensions/displays/pack-price/package.json
+++ b/apps/cms/extensions/displays/pack-price/package.json
@@ -6,7 +6,7 @@
     "type": "display",
     "path": "index.js",
     "source": "src/index.ts",
-    "host": "9.1.2",
+    "host": "9.0.1",
     "hidden": false
   }
 }

--- a/apps/cms/extensions/interfaces/price-conversion/package.json
+++ b/apps/cms/extensions/interfaces/price-conversion/package.json
@@ -6,7 +6,7 @@
     "type": "interface",
     "path": "index.js",
     "source": "src/index.ts",
-    "host": "9.1.2",
+    "host": "9.0.1",
     "hidden": false
   }
 }

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -24,12 +24,12 @@
   "dependencies": {
     "canvas": "2.8.0",
     "dinero.js": "2.0.0-alpha.8",
-    "directus": "9.1.2",
+    "directus": "9.0.1",
     "env-var": "7.1.1",
     "pg": "8.7.1"
   },
   "devDependencies": {
-    "@directus/extensions-sdk": "9.1.2",
+    "@directus/extensions-sdk": "9.0.1",
     "axios": "0.24.0",
     "form-data": "4.0.0",
     "rosie": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,12 +69,12 @@
       "dependencies": {
         "canvas": "2.8.0",
         "dinero.js": "2.0.0-alpha.8",
-        "directus": "9.1.2",
+        "directus": "9.0.1",
         "env-var": "7.1.1",
         "pg": "8.7.1"
       },
       "devDependencies": {
-        "@directus/extensions-sdk": "9.1.2",
+        "@directus/extensions-sdk": "9.0.1",
         "axios": "0.24.0",
         "form-data": "4.0.0",
         "rosie": "2.1.0",
@@ -86,13 +86,446 @@
         "npm": ">=7"
       }
     },
+    "apps/cms/node_modules/@directus/app": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/app/-/app-9.0.1.tgz",
+      "integrity": "sha512-t/f31imT4ATVnvYLG3YqQ5UXNsO0lnRAoqHhHmbDRE67ejF0njDEYgFNlgi3ipHKt3CXn+ny2cWInUQ3Q9jVqw=="
+    },
+    "apps/cms/node_modules/@directus/drive": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/drive/-/drive-9.0.1.tgz",
+      "integrity": "sha512-aQ1wwlT4en2xcuRx7jg4g3xORMg1MN5FnIeStvr4T/ueG51fxWtCKSIqLgfiCdN7qjAq1fHeD7Y+8GZ8tF7c4w==",
+      "dependencies": {
+        "fs-extra": "^10.0.0",
+        "node-exceptions": "^4.0.1"
+      }
+    },
+    "apps/cms/node_modules/@directus/drive-azure": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/drive-azure/-/drive-azure-9.0.1.tgz",
+      "integrity": "sha512-sUZ6zEbUWJ0MHD+YWjTx6lIYYYCHYU+e/Y83X88uPoNsqpaoCQbVpuPhtRMV0XeCO93ggCC57urh+Acjnl4kbw==",
+      "dependencies": {
+        "@azure/storage-blob": "^12.6.0",
+        "@directus/drive": "9.0.1",
+        "normalize-path": "^3.0.0"
+      }
+    },
+    "apps/cms/node_modules/@directus/drive-gcs": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/drive-gcs/-/drive-gcs-9.0.1.tgz",
+      "integrity": "sha512-s5EOAySaBWZ6nxgSRrBVt8eQqBKMSU6SSrvlKhul/SZszg72LGXSdXH4XXosGVyJeGC7ZPkYzSesyfOFoJLqIw==",
+      "dependencies": {
+        "@directus/drive": "9.0.1",
+        "@google-cloud/storage": "^5.8.5",
+        "lodash": "4.17.21",
+        "normalize-path": "^3.0.0"
+      }
+    },
+    "apps/cms/node_modules/@directus/drive-s3": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/drive-s3/-/drive-s3-9.0.1.tgz",
+      "integrity": "sha512-qb0siPkPTrxJROjQHxfbASfo5d/lXRRMThovWFJvHTGjGPBj6HNxoVhpU0wXk7VKjDwKpYCTv+7EhCuWPMCAMg==",
+      "dependencies": {
+        "@directus/drive": "9.0.1",
+        "aws-sdk": "^2.928.0",
+        "normalize-path": "^3.0.0"
+      }
+    },
+    "apps/cms/node_modules/@directus/extensions-sdk": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/extensions-sdk/-/extensions-sdk-9.0.1.tgz",
+      "integrity": "sha512-iC9HbUFcWN5Hxj98S3aujeVPdT7bb4uEX+CB9RhnssmHZINufzh8FY55tM91gmkyqGaA1WAIHGMf0saUwUrl6A==",
+      "dependencies": {
+        "@directus/shared": "9.0.1",
+        "@rollup/plugin-commonjs": "^21.0.0",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.0.0",
+        "@rollup/plugin-replace": "^3.0.0",
+        "@vue/compiler-sfc": "^3.1.1",
+        "chalk": "^4.1.1",
+        "commander": "^8.0.0",
+        "execa": "^5.1.1",
+        "fs-extra": "^10.0.0",
+        "ora": "^5.4.0",
+        "rollup": "^2.51.2",
+        "rollup-plugin-styles": "^3.14.1",
+        "rollup-plugin-terser": "^7.0.2",
+        "rollup-plugin-typescript2": "^0.30.0",
+        "rollup-plugin-vue": "^6.0.0"
+      },
+      "bin": {
+        "directus-extension": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "apps/cms/node_modules/@directus/format-title": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/format-title/-/format-title-9.0.1.tgz",
+      "integrity": "sha512-O+B7pz6wy44r17HYBUJozJ/D3nRviuFdkJ9gbzjUasDYBqYpukCS5q/ez2/B1XcpvVa+PpY8kd4Cd4KT0oCtZA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "apps/cms/node_modules/@directus/schema": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/schema/-/schema-9.0.1.tgz",
+      "integrity": "sha512-3EFl6eIOdRIsbpnRMTyKBhM2NOR/dPxATX267EzFgEAwFa8TtrwdjxXBhMq1YJ44yklkldld0nK5L/1C+EsjHg==",
+      "dependencies": {
+        "knex-schema-inspector": "1.6.4",
+        "lodash": "^4.17.21"
+      }
+    },
+    "apps/cms/node_modules/@directus/shared": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/shared/-/shared-9.0.1.tgz",
+      "integrity": "sha512-WgHFXr5lW4YjA0ZL2D1nldRrlikJS5xMGr4K2Fy4jNjBrZ2H85zayt7cHArPg+V4AS7kTXE+PJAxTzB9lRDjRA==",
+      "dependencies": {
+        "axios": "*",
+        "date-fns": "2.24.0",
+        "express": "*",
+        "fs-extra": "10.0.0",
+        "geojson": "*",
+        "joi": "17.4.2",
+        "knex": "*",
+        "knex-schema-inspector": "*",
+        "lodash": "4.17.21",
+        "pino": "*",
+        "vue": "3",
+        "vue-i18n": "9",
+        "vue-router": "4"
+      }
+    },
+    "apps/cms/node_modules/@directus/specs": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@directus/specs/-/specs-9.0.1.tgz",
+      "integrity": "sha512-dIzNmxoVDMHoXyfOrvkCGDcQMPI8imCwyZ+0XumSiUffxWBfn9bk1U9bHNqLWUagGJzHlBFmK5UaIrjwDh42Aw==",
+      "dependencies": {
+        "openapi3-ts": "^2.0.1"
+      }
+    },
+    "apps/cms/node_modules/@rollup/pluginutils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+      "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "apps/cms/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "apps/cms/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "apps/cms/node_modules/axios": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.4"
+      }
+    },
+    "apps/cms/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "apps/cms/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "apps/cms/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "apps/cms/node_modules/directus": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/directus/-/directus-9.0.1.tgz",
+      "integrity": "sha512-H39tbhfubktP4T2w4SLSHxwXCsist1NLSA3S7AdTIZz7bA0ksL3WXarN9PTniRN5N+1VMX8GxEH7vdl99N1fuA==",
+      "dependencies": {
+        "@aws-sdk/client-ses": "^3.40.0",
+        "@directus/app": "9.0.1",
+        "@directus/drive": "9.0.1",
+        "@directus/drive-azure": "9.0.1",
+        "@directus/drive-gcs": "9.0.1",
+        "@directus/drive-s3": "9.0.1",
+        "@directus/extensions-sdk": "9.0.1",
+        "@directus/format-title": "9.0.1",
+        "@directus/schema": "9.0.1",
+        "@directus/shared": "9.0.1",
+        "@directus/specs": "9.0.1",
+        "@godaddy/terminus": "^4.9.0",
+        "@rollup/plugin-alias": "^3.1.2",
+        "@rollup/plugin-virtual": "^2.0.3",
+        "argon2": "^0.28.2",
+        "async": "^3.2.0",
+        "async-mutex": "^0.3.1",
+        "atob": "^2.1.2",
+        "axios": "^0.24.0",
+        "busboy": "^0.3.1",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.1",
+        "commander": "^8.0.0",
+        "cookie-parser": "^1.4.5",
+        "cors": "^2.8.5",
+        "csv-parser": "^3.0.0",
+        "date-fns": "^2.22.1",
+        "deep-diff": "^1.0.2",
+        "deep-map": "^2.0.0",
+        "destroy": "^1.0.4",
+        "dotenv": "^10.0.0",
+        "eventemitter2": "^6.4.3",
+        "execa": "^5.1.1",
+        "exifr": "^7.1.2",
+        "express": "^4.17.1",
+        "flat": "^5.0.2",
+        "fs-extra": "^10.0.0",
+        "graphql": "^15.5.0",
+        "graphql-compose": "^9.0.1",
+        "inquirer": "^8.1.1",
+        "joi": "^17.3.0",
+        "js-yaml": "^4.1.0",
+        "js2xmlparser": "^4.0.1",
+        "json2csv": "^5.0.3",
+        "jsonwebtoken": "^8.5.1",
+        "keyv": "^4.0.3",
+        "knex": "^0.95.11",
+        "knex-schema-inspector": "1.6.4",
+        "ldapjs": "^2.3.1",
+        "liquidjs": "^9.25.0",
+        "lodash": "^4.17.21",
+        "macos-release": "^2.4.1",
+        "mime-types": "^2.1.31",
+        "ms": "^2.1.3",
+        "nanoid": "^3.1.23",
+        "node-cron": "^3.0.0",
+        "node-machine-id": "^1.1.12",
+        "nodemailer": "^6.6.1",
+        "object-hash": "^2.2.0",
+        "openapi3-ts": "^2.0.0",
+        "openid-client": "^5.0.0",
+        "ora": "^5.4.0",
+        "otplib": "^12.0.1",
+        "pino": "6.13.3",
+        "pino-colada": "^2.1.0",
+        "pino-http": "5.8.0",
+        "qs": "^6.9.4",
+        "rate-limiter-flexible": "^2.2.2",
+        "resolve-cwd": "^3.0.0",
+        "rollup": "^2.52.1",
+        "sharp": "^0.29.0",
+        "stream-json": "^1.7.1",
+        "supertest": "^6.1.6",
+        "update-check": "^1.5.4",
+        "uuid": "^8.3.2",
+        "uuid-validate": "0.0.3",
+        "wellknown": "^0.5.0"
+      },
+      "bin": {
+        "directus": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "optionalDependencies": {
+        "@keyv/redis": "^2.1.2",
+        "connect-memcached": "^1.0.0",
+        "connect-redis": "^6.0.0",
+        "connect-session-knex": "^2.1.0",
+        "ioredis": "^4.27.6",
+        "keyv-memcache": "^1.2.5",
+        "memcached": "^2.2.2",
+        "mysql": "^2.18.1",
+        "nodemailer-mailgun-transport": "^2.1.3",
+        "pg": "^8.6.0",
+        "sqlite3": "^5.0.2",
+        "tedious": "^13.0.0"
+      }
+    },
+    "apps/cms/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/cms/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "apps/cms/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "apps/cms/node_modules/knex-schema-inspector": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.4.tgz",
+      "integrity": "sha512-OCmicnMAaC109heNx79S3aYzTK4B9n+8uQ8z4ZBdqr8DN2E+xP9hLMpxfZFZkHMjilSQy13PgzfgvbgFgRNGSg==",
+      "dependencies": {
+        "lodash.flatten": "^4.4.0",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "apps/cms/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "apps/cms/node_modules/pino": {
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
+      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
+      "dependencies": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.8",
+        "fastify-warning": "^0.2.0",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "quick-format-unescaped": "^4.0.3",
+        "sonic-boom": "^1.0.2"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "apps/cms/node_modules/pino-http": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.8.0.tgz",
+      "integrity": "sha512-YwXiyRb9y0WCD1P9PcxuJuh3Dc5qmXde/paJE86UGYRdiFOi828hR9iUGmk5gaw6NBT9gLtKANOHFimvh19U5w==",
+      "dependencies": {
+        "fast-url-parser": "^1.1.3",
+        "pino": "^6.13.0",
+        "pino-std-serializers": "^4.0.0"
+      }
+    },
+    "apps/cms/node_modules/pino/node_modules/pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+    },
+    "apps/cms/node_modules/qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "apps/cms/node_modules/rollup-plugin-typescript2": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz",
+      "integrity": "sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==",
+      "dependencies": {
+        "@rollup/pluginutils": "^4.1.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "8.1.0",
+        "resolve": "1.20.0",
+        "tslib": "2.1.0"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.26.3",
+        "typescript": ">=2.4.0"
+      }
+    },
+    "apps/cms/node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "apps/cms/node_modules/sonic-boom": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
+    },
+    "apps/cms/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/cms/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+    },
+    "apps/cms/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "apps/web": {
@@ -3178,198 +3611,6 @@
       "version": "2.0.0-alpha.8",
       "resolved": "https://registry.npmjs.org/@dinero.js/currencies/-/currencies-2.0.0-alpha.8.tgz",
       "integrity": "sha512-zApiqtuuPwjiM9LJA5/kNcT48VSHRiz2/mktkXjIpfxrJKzthXybUAgEenExIH6dYhLDgVmsLQZtZFOsdYl0Ag=="
-    },
-    "node_modules/@directus/app": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/app/-/app-9.1.2.tgz",
-      "integrity": "sha512-8iFuBco4Y2rZS/UXVFx7Z0hTvMMxp8U/OKjM4Vgz6Big4Vr5rPKUx41Twz+Rr5hg2ogio6GNyIjcuePyGgpCUg=="
-    },
-    "node_modules/@directus/drive": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/drive/-/drive-9.1.2.tgz",
-      "integrity": "sha512-vQmWcWcjhXLGZW787bqNUYdvw/JODh2uRhEPNDJ4zPLiDHwNY/aUNT62DWviZtpBPJ536CAe1XF6mP7Pwu0fHQ==",
-      "dependencies": {
-        "fs-extra": "^10.0.0",
-        "node-exceptions": "^4.0.1"
-      }
-    },
-    "node_modules/@directus/drive-azure": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/drive-azure/-/drive-azure-9.1.2.tgz",
-      "integrity": "sha512-WKq00d//rAlwZqASp0K2hDTuh06FldIz83eKfPgZD0NJMNNbjkXcarAgYuFG0H3tv5tvH40h41YPXnxoQxNigw==",
-      "dependencies": {
-        "@azure/storage-blob": "^12.6.0",
-        "@directus/drive": "9.1.2",
-        "normalize-path": "^3.0.0"
-      }
-    },
-    "node_modules/@directus/drive-gcs": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/drive-gcs/-/drive-gcs-9.1.2.tgz",
-      "integrity": "sha512-E1sh5lfXLKv9+iVE3fdrRyZjxghQxPcpaoZUQoxMPzPRdof9R7x9Ed+GqFb7c/7vGAs04DTqxGoimAKlJQSfhQ==",
-      "dependencies": {
-        "@directus/drive": "9.1.2",
-        "@google-cloud/storage": "^5.8.5",
-        "lodash": "4.17.21",
-        "normalize-path": "^3.0.0"
-      }
-    },
-    "node_modules/@directus/drive-s3": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/drive-s3/-/drive-s3-9.1.2.tgz",
-      "integrity": "sha512-cst6rzzjRBOUhAbsF9sqWSrXLVEWHNOL63HrW098zYbCQjH0C+/ci66oEDaUzIQ6igfv+y02atZTcMAH97cBZw==",
-      "dependencies": {
-        "@directus/drive": "9.1.2",
-        "aws-sdk": "^2.928.0",
-        "normalize-path": "^3.0.0"
-      }
-    },
-    "node_modules/@directus/extensions-sdk": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/extensions-sdk/-/extensions-sdk-9.1.2.tgz",
-      "integrity": "sha512-uxf3AK2zPrFFHDjfy2vNokwwqIZh5eHLRgvfu6GfQY7JxXA5Ot8yj3o0m1+YmGZrmaghnaDNE1KPWXWhYfF9Ow==",
-      "dependencies": {
-        "@directus/shared": "9.1.2",
-        "@rollup/plugin-commonjs": "^21.0.0",
-        "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^13.0.0",
-        "@rollup/plugin-replace": "^3.0.0",
-        "@vue/compiler-sfc": "^3.1.1",
-        "chalk": "^4.1.1",
-        "commander": "^8.0.0",
-        "execa": "^5.1.1",
-        "fs-extra": "^10.0.0",
-        "ora": "^5.4.0",
-        "rollup": "^2.51.2",
-        "rollup-plugin-styles": "^3.14.1",
-        "rollup-plugin-terser": "^7.0.2",
-        "rollup-plugin-typescript2": "^0.31.0",
-        "rollup-plugin-vue": "^6.0.0"
-      },
-      "bin": {
-        "directus-extension": "cli.js"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@directus/extensions-sdk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@directus/extensions-sdk/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@directus/extensions-sdk/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@directus/extensions-sdk/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@directus/extensions-sdk/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@directus/extensions-sdk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@directus/format-title": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/format-title/-/format-title-9.1.2.tgz",
-      "integrity": "sha512-FbFFebyUBcYU29MmMBB2HS2tIDM3KjiMR2ah/Ehhr5m1Uzd1tPaGsZcq5DPofKslFVrB+yH922ywHQJhA5oHfQ==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@directus/schema": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/schema/-/schema-9.1.2.tgz",
-      "integrity": "sha512-Igke2iEKw0I8ouXY3ibgiiEIU6gLlE5FiPFYHrpHp0cF7W8ZSlklv6O/oZOXBBHkS7H3ZVBr0BsQljUCrwSS3A==",
-      "dependencies": {
-        "knex-schema-inspector": "1.6.4",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@directus/schema/node_modules/knex-schema-inspector": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.4.tgz",
-      "integrity": "sha512-OCmicnMAaC109heNx79S3aYzTK4B9n+8uQ8z4ZBdqr8DN2E+xP9hLMpxfZFZkHMjilSQy13PgzfgvbgFgRNGSg==",
-      "dependencies": {
-        "lodash.flatten": "^4.4.0",
-        "lodash.isnil": "^4.0.0"
-      }
-    },
-    "node_modules/@directus/shared": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/shared/-/shared-9.1.2.tgz",
-      "integrity": "sha512-dpUP0ldBXdXk0ZufsaCNvpgt5liTgxWogN9CObES6Q26cdeYVVbnJaZehkazzXCgoScdlAUEjC0PCHIZrs7Z+g==",
-      "dependencies": {
-        "axios": "*",
-        "date-fns": "2.24.0",
-        "express": "*",
-        "fs-extra": "10.0.0",
-        "geojson": "*",
-        "joi": "17.4.2",
-        "knex": "*",
-        "knex-schema-inspector": "*",
-        "lodash": "4.17.21",
-        "pino": "*",
-        "vue": "3",
-        "vue-i18n": "9",
-        "vue-router": "4"
-      }
-    },
-    "node_modules/@directus/specs": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/specs/-/specs-9.1.2.tgz",
-      "integrity": "sha512-j2df76sgoJUKVW1+8MPK47JfZ4X+udYOsnaszK8KE0P5p2RzMm4zZNzZEFPS8Ig4i9mW5Q/Xhdiox1vqF7XISw==",
-      "dependencies": {
-        "openapi3-ts": "^2.0.1"
-      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.0.4",
@@ -6516,15 +6757,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@ts-type/package-dts": {
-      "version": "1.0.54",
-      "resolved": "https://registry.npmjs.org/@ts-type/package-dts/-/package-dts-1.0.54.tgz",
-      "integrity": "sha512-lJWJBVfPCbPBdSWM3PGkooYl9p273n7A1nXB93vyHQIO+LWVXFi70ajj5GdgLU0cs+pwjdCE+1RoK/1EfC6a/A==",
-      "dependencies": {
-        "@types/semver": "^7.3.9",
-        "ts-type": "^2.0.3"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -6595,12 +6827,6 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
-    },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.36",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
-      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
-      "peer": true
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.0",
@@ -7031,11 +7257,6 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "devOptional": true
-    },
-    "node_modules/@types/semver": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
-      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
@@ -7489,71 +7710,6 @@
       },
       "peerDependencies": {
         "react": "^16 || ^17"
-      }
-    },
-    "node_modules/@yarn-tool/resolve-package": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@yarn-tool/resolve-package/-/resolve-package-1.0.39.tgz",
-      "integrity": "sha512-Muv+aW1tcyPhkwG4db3fP/KjknzJMidykLbrwEdU0fI0C6DFzBehhLLu9Z/rIO26OoJWqprxyR27w+SgNXNOoQ==",
-      "dependencies": {
-        "@ts-type/package-dts": "^1.0.54",
-        "pkg-dir": "< 6 >= 5",
-        "tslib": "^2.3.1",
-        "upath2": "^3.1.10"
-      }
-    },
-    "node_modules/@yarn-tool/resolve-package/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@yarn-tool/resolve-package/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@yarn-tool/resolve-package/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@yarn-tool/resolve-package/node_modules/pkg-dir": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-      "dependencies": {
-        "find-up": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/abab": {
@@ -11042,269 +11198,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/directus": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/directus/-/directus-9.1.2.tgz",
-      "integrity": "sha512-vhOcYsRlXe45RTI1o+D3mc4EAb819a/fH94P9vklUEHqIu/AeD9bMwD1LRAQnUI5SvzCaLI788SMiLBrnws3Aw==",
-      "dependencies": {
-        "@aws-sdk/client-ses": "^3.40.0",
-        "@directus/app": "9.1.2",
-        "@directus/drive": "9.1.2",
-        "@directus/drive-azure": "9.1.2",
-        "@directus/drive-gcs": "9.1.2",
-        "@directus/drive-s3": "9.1.2",
-        "@directus/extensions-sdk": "9.1.2",
-        "@directus/format-title": "9.1.2",
-        "@directus/schema": "9.1.2",
-        "@directus/shared": "9.1.2",
-        "@directus/specs": "9.1.2",
-        "@godaddy/terminus": "^4.9.0",
-        "@rollup/plugin-alias": "^3.1.2",
-        "@rollup/plugin-virtual": "^2.0.3",
-        "argon2": "^0.28.2",
-        "async": "^3.2.0",
-        "async-mutex": "^0.3.1",
-        "atob": "^2.1.2",
-        "axios": "^0.24.0",
-        "busboy": "^0.3.1",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.1",
-        "commander": "^8.0.0",
-        "cookie-parser": "^1.4.5",
-        "cors": "^2.8.5",
-        "csv-parser": "^3.0.0",
-        "date-fns": "^2.22.1",
-        "deep-diff": "^1.0.2",
-        "deep-map": "^2.0.0",
-        "destroy": "^1.0.4",
-        "dotenv": "^10.0.0",
-        "eventemitter2": "^6.4.3",
-        "execa": "^5.1.1",
-        "exifr": "^7.1.2",
-        "express": "^4.17.1",
-        "flat": "^5.0.2",
-        "fs-extra": "^10.0.0",
-        "graphql": "^15.5.0",
-        "graphql-compose": "^9.0.1",
-        "inquirer": "^8.1.1",
-        "joi": "^17.3.0",
-        "js-yaml": "^4.1.0",
-        "js2xmlparser": "^4.0.1",
-        "json2csv": "^5.0.3",
-        "jsonwebtoken": "^8.5.1",
-        "keyv": "^4.0.3",
-        "knex": "^0.95.11",
-        "knex-schema-inspector": "1.6.4",
-        "ldapjs": "^2.3.1",
-        "liquidjs": "^9.25.0",
-        "lodash": "^4.17.21",
-        "macos-release": "^2.4.1",
-        "marked": "^4.0.3",
-        "mime-types": "^2.1.31",
-        "ms": "^2.1.3",
-        "nanoid": "^3.1.23",
-        "node-cron": "^3.0.0",
-        "node-machine-id": "^1.1.12",
-        "nodemailer": "^6.6.1",
-        "object-hash": "^2.2.0",
-        "openapi3-ts": "^2.0.0",
-        "openid-client": "^5.0.0",
-        "ora": "^5.4.0",
-        "otplib": "^12.0.1",
-        "pino": "6.13.3",
-        "pino-colada": "^2.1.0",
-        "pino-http": "5.8.0",
-        "qs": "^6.9.4",
-        "rate-limiter-flexible": "^2.2.2",
-        "resolve-cwd": "^3.0.0",
-        "rollup": "^2.52.1",
-        "sanitize-html": "^2.6.0",
-        "sharp": "^0.29.0",
-        "stream-json": "^1.7.1",
-        "supertest": "^6.1.6",
-        "update-check": "^1.5.4",
-        "uuid": "^8.3.2",
-        "uuid-validate": "0.0.3",
-        "wellknown": "^0.5.0"
-      },
-      "bin": {
-        "directus": "cli.js"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "optionalDependencies": {
-        "@keyv/redis": "^2.1.2",
-        "connect-memcached": "^1.0.0",
-        "connect-redis": "^6.0.0",
-        "connect-session-knex": "^2.1.0",
-        "ioredis": "^4.27.6",
-        "keyv-memcache": "^1.2.5",
-        "memcached": "^2.2.2",
-        "mysql": "^2.18.1",
-        "nodemailer-mailgun-transport": "^2.1.3",
-        "pg": "^8.6.0",
-        "sqlite3": "^5.0.2",
-        "tedious": "^13.0.0"
-      }
-    },
-    "node_modules/directus/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/directus/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/directus/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/directus/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/directus/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/directus/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/directus/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/directus/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/directus/node_modules/knex-schema-inspector": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.4.tgz",
-      "integrity": "sha512-OCmicnMAaC109heNx79S3aYzTK4B9n+8uQ8z4ZBdqr8DN2E+xP9hLMpxfZFZkHMjilSQy13PgzfgvbgFgRNGSg==",
-      "dependencies": {
-        "lodash.flatten": "^4.4.0",
-        "lodash.isnil": "^4.0.0"
-      }
-    },
-    "node_modules/directus/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/directus/node_modules/pino": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
-      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
-      "dependencies": {
-        "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
-        "fastify-warning": "^0.2.0",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
-        "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/directus/node_modules/pino-http": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.8.0.tgz",
-      "integrity": "sha512-YwXiyRb9y0WCD1P9PcxuJuh3Dc5qmXde/paJE86UGYRdiFOi828hR9iUGmk5gaw6NBT9gLtKANOHFimvh19U5w==",
-      "dependencies": {
-        "fast-url-parser": "^1.1.3",
-        "pino": "^6.13.0",
-        "pino-std-serializers": "^4.0.0"
-      }
-    },
-    "node_modules/directus/node_modules/pino/node_modules/pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
-    },
-    "node_modules/directus/node_modules/qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/directus/node_modules/sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
-      }
-    },
-    "node_modules/directus/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -11385,31 +11278,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/domhandler": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
-      "integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domhandler/node_modules/domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ]
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -14604,61 +14472,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ]
-    },
-    "node_modules/htmlparser2/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/http-assert": {
@@ -18120,15 +17933,6 @@
         }
       }
     },
-    "node_modules/knex-schema-inspector": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.6.tgz",
-      "integrity": "sha512-tiG35ttP0g/EwXTb2+vSRYK3++7eetaaojauIHjXwocdQqsRNNhEfouCMdmE+WcaMmM7dm+sJhYD5QHh2lVmxA==",
-      "dependencies": {
-        "lodash.flatten": "^4.4.0",
-        "lodash.isnil": "^4.0.0"
-      }
-    },
     "node_modules/knex/node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -19193,17 +18997,6 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.6.tgz",
-      "integrity": "sha512-+H0bTf8DM8zLuFBUm/2VklxaCrwlBFgoJzHJcMZCnZ9cPgsllHwKpL6TPLdDeA38yPluMuVKOL1hO5w6HmG5Mg==",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/md5.js": {
@@ -21665,11 +21458,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
-    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -21705,14 +21493,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-is-network-drive": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/path-is-network-drive/-/path-is-network-drive-1.0.10.tgz",
-      "integrity": "sha512-D6kJYPUSKGZBpTM2nv10sOWNdC056p4JDx0y7ARe6gop0aXXm5G86Gn/SyKvaf0Ce8c9Guctf+J+qoFmzuhDQg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -21725,14 +21505,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "node_modules/path-strip-sep": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-strip-sep/-/path-strip-sep-1.0.7.tgz",
-      "integrity": "sha512-9xDVZPblHde4lTuTDnwqBKr9LTbPZW+Iae63ho500+BpEiZe3X6wvLInHgbB6FSMtwCTvztljw3k2zcNDNESzg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -25376,69 +25148,6 @@
         "typescript": "^4"
       }
     },
-    "node_modules/rollup-plugin-typescript2": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.1.tgz",
-      "integrity": "sha512-sklqXuQwQX+stKi4kDfEkneVESPi3YM/2S899vfRdF9Yi40vcC50Oq4A4cSZJNXsAQE/UsBZl5fAOsBLziKmjw==",
-      "dependencies": {
-        "@rollup/pluginutils": "^4.1.0",
-        "@yarn-tool/resolve-package": "^1.0.36",
-        "find-cache-dir": "^3.3.1",
-        "fs-extra": "8.1.0",
-        "resolve": "1.20.0",
-        "tslib": "2.2.0"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.26.3",
-        "typescript": ">=2.4.0"
-      }
-    },
-    "node_modules/rollup-plugin-typescript2/node_modules/@rollup/pluginutils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
-      "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/rollup-plugin-typescript2/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/rollup-plugin-typescript2/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-    },
-    "node_modules/rollup-plugin-typescript2/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/rollup-plugin-vue": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz",
@@ -25552,38 +25261,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/sanitize-html": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.6.0.tgz",
-      "integrity": "sha512-qc+NqTeaOi/QVAVs5gOY9tqIVk4r1pcUbx1Q2N1a609Os3TNlm85zll2d8g8m/RM6RWg9llir0SpAcePQVIC1w==",
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^6.0.0",
-        "is-plain-object": "^5.0.0",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/sax": {
       "version": "1.2.1",
@@ -27829,26 +27506,6 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
-    "node_modules/ts-toolbelt": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
-      "peer": true
-    },
-    "node_modules/ts-type": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-2.0.3.tgz",
-      "integrity": "sha512-Cc2kgkUwmCK/h2m/sVbr2piqOGE+Hs4qAgJ7CiI4OSMJFWorE6f6yoisjSBE5izGb2/VZnHSN2CcOQR6/Yfazw==",
-      "dependencies": {
-        "tslib": "^2.3.1",
-        "typedarray-dts": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@types/bluebird": "*",
-        "@types/node": "*",
-        "ts-toolbelt": "^9.6.0"
-      }
-    },
     "node_modules/tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -28024,11 +27681,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
-    "node_modules/typedarray-dts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
-      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA=="
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -28152,20 +27804,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/upath2": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/upath2/-/upath2-3.1.10.tgz",
-      "integrity": "sha512-7ph3GzTaVbQX+oIoMsGtM+9BAWQr+6Mn28TJKPu28+yGpZ+J4am590CPDBlDG0zyuo9T9T7o21ciqNzwIp/q0A==",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "path-is-network-drive": "^1.0.10",
-        "path-strip-sep": "^1.0.7",
-        "tslib": "^2.3.1"
-      },
-      "peerDependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/update-check": {
@@ -29247,11 +28885,11 @@
     "@algomart/cms": {
       "version": "file:apps/cms",
       "requires": {
-        "@directus/extensions-sdk": "9.1.2",
+        "@directus/extensions-sdk": "9.0.1",
         "axios": "0.24.0",
         "canvas": "2.8.0",
         "dinero.js": "2.0.0-alpha.8",
-        "directus": "9.1.2",
+        "directus": "9.0.1",
         "env-var": "7.1.1",
         "form-data": "4.0.0",
         "pg": "8.7.1",
@@ -29260,14 +28898,388 @@
         "vue": "3.2.22"
       },
       "dependencies": {
+        "@directus/app": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/app/-/app-9.0.1.tgz",
+          "integrity": "sha512-t/f31imT4ATVnvYLG3YqQ5UXNsO0lnRAoqHhHmbDRE67ejF0njDEYgFNlgi3ipHKt3CXn+ny2cWInUQ3Q9jVqw=="
+        },
+        "@directus/drive": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/drive/-/drive-9.0.1.tgz",
+          "integrity": "sha512-aQ1wwlT4en2xcuRx7jg4g3xORMg1MN5FnIeStvr4T/ueG51fxWtCKSIqLgfiCdN7qjAq1fHeD7Y+8GZ8tF7c4w==",
+          "requires": {
+            "fs-extra": "^10.0.0",
+            "node-exceptions": "^4.0.1"
+          }
+        },
+        "@directus/drive-azure": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/drive-azure/-/drive-azure-9.0.1.tgz",
+          "integrity": "sha512-sUZ6zEbUWJ0MHD+YWjTx6lIYYYCHYU+e/Y83X88uPoNsqpaoCQbVpuPhtRMV0XeCO93ggCC57urh+Acjnl4kbw==",
+          "requires": {
+            "@azure/storage-blob": "^12.6.0",
+            "@directus/drive": "9.0.1",
+            "normalize-path": "^3.0.0"
+          }
+        },
+        "@directus/drive-gcs": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/drive-gcs/-/drive-gcs-9.0.1.tgz",
+          "integrity": "sha512-s5EOAySaBWZ6nxgSRrBVt8eQqBKMSU6SSrvlKhul/SZszg72LGXSdXH4XXosGVyJeGC7ZPkYzSesyfOFoJLqIw==",
+          "requires": {
+            "@directus/drive": "9.0.1",
+            "@google-cloud/storage": "^5.8.5",
+            "lodash": "4.17.21",
+            "normalize-path": "^3.0.0"
+          }
+        },
+        "@directus/drive-s3": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/drive-s3/-/drive-s3-9.0.1.tgz",
+          "integrity": "sha512-qb0siPkPTrxJROjQHxfbASfo5d/lXRRMThovWFJvHTGjGPBj6HNxoVhpU0wXk7VKjDwKpYCTv+7EhCuWPMCAMg==",
+          "requires": {
+            "@directus/drive": "9.0.1",
+            "aws-sdk": "^2.928.0",
+            "normalize-path": "^3.0.0"
+          }
+        },
+        "@directus/extensions-sdk": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/extensions-sdk/-/extensions-sdk-9.0.1.tgz",
+          "integrity": "sha512-iC9HbUFcWN5Hxj98S3aujeVPdT7bb4uEX+CB9RhnssmHZINufzh8FY55tM91gmkyqGaA1WAIHGMf0saUwUrl6A==",
+          "requires": {
+            "@directus/shared": "9.0.1",
+            "@rollup/plugin-commonjs": "^21.0.0",
+            "@rollup/plugin-json": "^4.1.0",
+            "@rollup/plugin-node-resolve": "^13.0.0",
+            "@rollup/plugin-replace": "^3.0.0",
+            "@vue/compiler-sfc": "^3.1.1",
+            "chalk": "^4.1.1",
+            "commander": "^8.0.0",
+            "execa": "^5.1.1",
+            "fs-extra": "^10.0.0",
+            "ora": "^5.4.0",
+            "rollup": "^2.51.2",
+            "rollup-plugin-styles": "^3.14.1",
+            "rollup-plugin-terser": "^7.0.2",
+            "rollup-plugin-typescript2": "^0.30.0",
+            "rollup-plugin-vue": "^6.0.0"
+          }
+        },
+        "@directus/format-title": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/format-title/-/format-title-9.0.1.tgz",
+          "integrity": "sha512-O+B7pz6wy44r17HYBUJozJ/D3nRviuFdkJ9gbzjUasDYBqYpukCS5q/ez2/B1XcpvVa+PpY8kd4Cd4KT0oCtZA=="
+        },
+        "@directus/schema": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/schema/-/schema-9.0.1.tgz",
+          "integrity": "sha512-3EFl6eIOdRIsbpnRMTyKBhM2NOR/dPxATX267EzFgEAwFa8TtrwdjxXBhMq1YJ44yklkldld0nK5L/1C+EsjHg==",
+          "requires": {
+            "knex-schema-inspector": "1.6.4",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@directus/shared": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/shared/-/shared-9.0.1.tgz",
+          "integrity": "sha512-WgHFXr5lW4YjA0ZL2D1nldRrlikJS5xMGr4K2Fy4jNjBrZ2H85zayt7cHArPg+V4AS7kTXE+PJAxTzB9lRDjRA==",
+          "requires": {
+            "axios": "*",
+            "date-fns": "2.24.0",
+            "express": "*",
+            "fs-extra": "10.0.0",
+            "geojson": "*",
+            "joi": "17.4.2",
+            "knex": "*",
+            "knex-schema-inspector": "*",
+            "lodash": "4.17.21",
+            "pino": "*",
+            "vue": "3",
+            "vue-i18n": "9",
+            "vue-router": "4"
+          }
+        },
+        "@directus/specs": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@directus/specs/-/specs-9.0.1.tgz",
+          "integrity": "sha512-dIzNmxoVDMHoXyfOrvkCGDcQMPI8imCwyZ+0XumSiUffxWBfn9bk1U9bHNqLWUagGJzHlBFmK5UaIrjwDh42Aw==",
+          "requires": {
+            "openapi3-ts": "^2.0.1"
+          }
+        },
+        "@rollup/pluginutils": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+          "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "axios": {
           "version": "0.24.0",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
           "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-          "dev": true,
           "requires": {
             "follow-redirects": "^1.14.4"
           }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "directus": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/directus/-/directus-9.0.1.tgz",
+          "integrity": "sha512-H39tbhfubktP4T2w4SLSHxwXCsist1NLSA3S7AdTIZz7bA0ksL3WXarN9PTniRN5N+1VMX8GxEH7vdl99N1fuA==",
+          "requires": {
+            "@aws-sdk/client-ses": "^3.40.0",
+            "@directus/app": "9.0.1",
+            "@directus/drive": "9.0.1",
+            "@directus/drive-azure": "9.0.1",
+            "@directus/drive-gcs": "9.0.1",
+            "@directus/drive-s3": "9.0.1",
+            "@directus/extensions-sdk": "9.0.1",
+            "@directus/format-title": "9.0.1",
+            "@directus/schema": "9.0.1",
+            "@directus/shared": "9.0.1",
+            "@directus/specs": "9.0.1",
+            "@godaddy/terminus": "^4.9.0",
+            "@keyv/redis": "^2.1.2",
+            "@rollup/plugin-alias": "^3.1.2",
+            "@rollup/plugin-virtual": "^2.0.3",
+            "argon2": "^0.28.2",
+            "async": "^3.2.0",
+            "async-mutex": "^0.3.1",
+            "atob": "^2.1.2",
+            "axios": "^0.24.0",
+            "busboy": "^0.3.1",
+            "camelcase": "^6.2.0",
+            "chalk": "^4.1.1",
+            "commander": "^8.0.0",
+            "connect-memcached": "^1.0.0",
+            "connect-redis": "^6.0.0",
+            "connect-session-knex": "^2.1.0",
+            "cookie-parser": "^1.4.5",
+            "cors": "^2.8.5",
+            "csv-parser": "^3.0.0",
+            "date-fns": "^2.22.1",
+            "deep-diff": "^1.0.2",
+            "deep-map": "^2.0.0",
+            "destroy": "^1.0.4",
+            "dotenv": "^10.0.0",
+            "eventemitter2": "^6.4.3",
+            "execa": "^5.1.1",
+            "exifr": "^7.1.2",
+            "express": "^4.17.1",
+            "flat": "^5.0.2",
+            "fs-extra": "^10.0.0",
+            "graphql": "^15.5.0",
+            "graphql-compose": "^9.0.1",
+            "inquirer": "^8.1.1",
+            "ioredis": "^4.27.6",
+            "joi": "^17.3.0",
+            "js-yaml": "^4.1.0",
+            "js2xmlparser": "^4.0.1",
+            "json2csv": "^5.0.3",
+            "jsonwebtoken": "^8.5.1",
+            "keyv": "^4.0.3",
+            "keyv-memcache": "^1.2.5",
+            "knex": "^0.95.11",
+            "knex-schema-inspector": "1.6.4",
+            "ldapjs": "^2.3.1",
+            "liquidjs": "^9.25.0",
+            "lodash": "^4.17.21",
+            "macos-release": "^2.4.1",
+            "memcached": "^2.2.2",
+            "mime-types": "^2.1.31",
+            "ms": "^2.1.3",
+            "mysql": "^2.18.1",
+            "nanoid": "^3.1.23",
+            "node-cron": "^3.0.0",
+            "node-machine-id": "^1.1.12",
+            "nodemailer": "^6.6.1",
+            "nodemailer-mailgun-transport": "^2.1.3",
+            "object-hash": "^2.2.0",
+            "openapi3-ts": "^2.0.0",
+            "openid-client": "^5.0.0",
+            "ora": "^5.4.0",
+            "otplib": "^12.0.1",
+            "pg": "^8.6.0",
+            "pino": "6.13.3",
+            "pino-colada": "^2.1.0",
+            "pino-http": "5.8.0",
+            "qs": "^6.9.4",
+            "rate-limiter-flexible": "^2.2.2",
+            "resolve-cwd": "^3.0.0",
+            "rollup": "^2.52.1",
+            "sharp": "^0.29.0",
+            "sqlite3": "^5.0.2",
+            "stream-json": "^1.7.1",
+            "supertest": "^6.1.6",
+            "tedious": "^13.0.0",
+            "update-check": "^1.5.4",
+            "uuid": "^8.3.2",
+            "uuid-validate": "0.0.3",
+            "wellknown": "^0.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "knex-schema-inspector": {
+          "version": "1.6.4",
+          "resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.4.tgz",
+          "integrity": "sha512-OCmicnMAaC109heNx79S3aYzTK4B9n+8uQ8z4ZBdqr8DN2E+xP9hLMpxfZFZkHMjilSQy13PgzfgvbgFgRNGSg==",
+          "requires": {
+            "lodash.flatten": "^4.4.0",
+            "lodash.isnil": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "pino": {
+          "version": "6.13.3",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
+          "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
+          "requires": {
+            "fast-redact": "^3.0.0",
+            "fast-safe-stringify": "^2.0.8",
+            "fastify-warning": "^0.2.0",
+            "flatstr": "^1.0.12",
+            "pino-std-serializers": "^3.1.0",
+            "quick-format-unescaped": "^4.0.3",
+            "sonic-boom": "^1.0.2"
+          },
+          "dependencies": {
+            "pino-std-serializers": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+              "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+            }
+          }
+        },
+        "pino-http": {
+          "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.8.0.tgz",
+          "integrity": "sha512-YwXiyRb9y0WCD1P9PcxuJuh3Dc5qmXde/paJE86UGYRdiFOi828hR9iUGmk5gaw6NBT9gLtKANOHFimvh19U5w==",
+          "requires": {
+            "fast-url-parser": "^1.1.3",
+            "pino": "^6.13.0",
+            "pino-std-serializers": "^4.0.0"
+          }
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "rollup-plugin-typescript2": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz",
+          "integrity": "sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==",
+          "requires": {
+            "@rollup/pluginutils": "^4.1.0",
+            "find-cache-dir": "^3.3.1",
+            "fs-extra": "8.1.0",
+            "resolve": "1.20.0",
+            "tslib": "2.1.0"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+              "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+              "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "sonic-boom": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+          "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "flatstr": "^1.0.12"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
       }
     },
@@ -31594,172 +31606,6 @@
       "version": "2.0.0-alpha.8",
       "resolved": "https://registry.npmjs.org/@dinero.js/currencies/-/currencies-2.0.0-alpha.8.tgz",
       "integrity": "sha512-zApiqtuuPwjiM9LJA5/kNcT48VSHRiz2/mktkXjIpfxrJKzthXybUAgEenExIH6dYhLDgVmsLQZtZFOsdYl0Ag=="
-    },
-    "@directus/app": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/app/-/app-9.1.2.tgz",
-      "integrity": "sha512-8iFuBco4Y2rZS/UXVFx7Z0hTvMMxp8U/OKjM4Vgz6Big4Vr5rPKUx41Twz+Rr5hg2ogio6GNyIjcuePyGgpCUg=="
-    },
-    "@directus/drive": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/drive/-/drive-9.1.2.tgz",
-      "integrity": "sha512-vQmWcWcjhXLGZW787bqNUYdvw/JODh2uRhEPNDJ4zPLiDHwNY/aUNT62DWviZtpBPJ536CAe1XF6mP7Pwu0fHQ==",
-      "requires": {
-        "fs-extra": "^10.0.0",
-        "node-exceptions": "^4.0.1"
-      }
-    },
-    "@directus/drive-azure": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/drive-azure/-/drive-azure-9.1.2.tgz",
-      "integrity": "sha512-WKq00d//rAlwZqASp0K2hDTuh06FldIz83eKfPgZD0NJMNNbjkXcarAgYuFG0H3tv5tvH40h41YPXnxoQxNigw==",
-      "requires": {
-        "@azure/storage-blob": "^12.6.0",
-        "@directus/drive": "9.1.2",
-        "normalize-path": "^3.0.0"
-      }
-    },
-    "@directus/drive-gcs": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/drive-gcs/-/drive-gcs-9.1.2.tgz",
-      "integrity": "sha512-E1sh5lfXLKv9+iVE3fdrRyZjxghQxPcpaoZUQoxMPzPRdof9R7x9Ed+GqFb7c/7vGAs04DTqxGoimAKlJQSfhQ==",
-      "requires": {
-        "@directus/drive": "9.1.2",
-        "@google-cloud/storage": "^5.8.5",
-        "lodash": "4.17.21",
-        "normalize-path": "^3.0.0"
-      }
-    },
-    "@directus/drive-s3": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/drive-s3/-/drive-s3-9.1.2.tgz",
-      "integrity": "sha512-cst6rzzjRBOUhAbsF9sqWSrXLVEWHNOL63HrW098zYbCQjH0C+/ci66oEDaUzIQ6igfv+y02atZTcMAH97cBZw==",
-      "requires": {
-        "@directus/drive": "9.1.2",
-        "aws-sdk": "^2.928.0",
-        "normalize-path": "^3.0.0"
-      }
-    },
-    "@directus/extensions-sdk": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/extensions-sdk/-/extensions-sdk-9.1.2.tgz",
-      "integrity": "sha512-uxf3AK2zPrFFHDjfy2vNokwwqIZh5eHLRgvfu6GfQY7JxXA5Ot8yj3o0m1+YmGZrmaghnaDNE1KPWXWhYfF9Ow==",
-      "requires": {
-        "@directus/shared": "9.1.2",
-        "@rollup/plugin-commonjs": "^21.0.0",
-        "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^13.0.0",
-        "@rollup/plugin-replace": "^3.0.0",
-        "@vue/compiler-sfc": "^3.1.1",
-        "chalk": "^4.1.1",
-        "commander": "^8.0.0",
-        "execa": "^5.1.1",
-        "fs-extra": "^10.0.0",
-        "ora": "^5.4.0",
-        "rollup": "^2.51.2",
-        "rollup-plugin-styles": "^3.14.1",
-        "rollup-plugin-terser": "^7.0.2",
-        "rollup-plugin-typescript2": "^0.31.0",
-        "rollup-plugin-vue": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@directus/format-title": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/format-title/-/format-title-9.1.2.tgz",
-      "integrity": "sha512-FbFFebyUBcYU29MmMBB2HS2tIDM3KjiMR2ah/Ehhr5m1Uzd1tPaGsZcq5DPofKslFVrB+yH922ywHQJhA5oHfQ=="
-    },
-    "@directus/schema": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/schema/-/schema-9.1.2.tgz",
-      "integrity": "sha512-Igke2iEKw0I8ouXY3ibgiiEIU6gLlE5FiPFYHrpHp0cF7W8ZSlklv6O/oZOXBBHkS7H3ZVBr0BsQljUCrwSS3A==",
-      "requires": {
-        "knex-schema-inspector": "1.6.4",
-        "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "knex-schema-inspector": {
-          "version": "1.6.4",
-          "resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.4.tgz",
-          "integrity": "sha512-OCmicnMAaC109heNx79S3aYzTK4B9n+8uQ8z4ZBdqr8DN2E+xP9hLMpxfZFZkHMjilSQy13PgzfgvbgFgRNGSg==",
-          "requires": {
-            "lodash.flatten": "^4.4.0",
-            "lodash.isnil": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@directus/shared": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/shared/-/shared-9.1.2.tgz",
-      "integrity": "sha512-dpUP0ldBXdXk0ZufsaCNvpgt5liTgxWogN9CObES6Q26cdeYVVbnJaZehkazzXCgoScdlAUEjC0PCHIZrs7Z+g==",
-      "requires": {
-        "axios": "*",
-        "date-fns": "2.24.0",
-        "express": "*",
-        "fs-extra": "10.0.0",
-        "geojson": "*",
-        "joi": "17.4.2",
-        "knex": "*",
-        "knex-schema-inspector": "*",
-        "lodash": "4.17.21",
-        "pino": "*",
-        "vue": "3",
-        "vue-i18n": "9",
-        "vue-router": "4"
-      }
-    },
-    "@directus/specs": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@directus/specs/-/specs-9.1.2.tgz",
-      "integrity": "sha512-j2df76sgoJUKVW1+8MPK47JfZ4X+udYOsnaszK8KE0P5p2RzMm4zZNzZEFPS8Ig4i9mW5Q/Xhdiox1vqF7XISw==",
-      "requires": {
-        "openapi3-ts": "^2.0.1"
-      }
     },
     "@eslint/eslintrc": {
       "version": "1.0.4",
@@ -34187,15 +34033,6 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "devOptional": true
     },
-    "@ts-type/package-dts": {
-      "version": "1.0.54",
-      "resolved": "https://registry.npmjs.org/@ts-type/package-dts/-/package-dts-1.0.54.tgz",
-      "integrity": "sha512-lJWJBVfPCbPBdSWM3PGkooYl9p273n7A1nXB93vyHQIO+LWVXFi70ajj5GdgLU0cs+pwjdCE+1RoK/1EfC6a/A==",
-      "requires": {
-        "@types/semver": "^7.3.9",
-        "ts-type": "^2.0.3"
-      }
-    },
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -34266,12 +34103,6 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
-    },
-    "@types/bluebird": {
-      "version": "3.5.36",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
-      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
-      "peer": true
     },
     "@types/bn.js": {
       "version": "5.1.0",
@@ -34694,11 +34525,6 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "devOptional": true
     },
-    "@types/semver": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
-      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
-    },
     "@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -35060,52 +34886,6 @@
       "integrity": "sha512-FQgi90jvC9uw2aALlonJfqaWOvU5UUBBVvdAnS2iryXwCc4YJkKsPJY5Y/LzaND3OIyk8XGUn1vTRn6hcem28Q==",
       "requires": {
         "lodash": "^4"
-      }
-    },
-    "@yarn-tool/resolve-package": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@yarn-tool/resolve-package/-/resolve-package-1.0.39.tgz",
-      "integrity": "sha512-Muv+aW1tcyPhkwG4db3fP/KjknzJMidykLbrwEdU0fI0C6DFzBehhLLu9Z/rIO26OoJWqprxyR27w+SgNXNOoQ==",
-      "requires": {
-        "@ts-type/package-dts": "^1.0.54",
-        "pkg-dir": "< 6 >= 5",
-        "tslib": "^2.3.1",
-        "upath2": "^3.1.10"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "pkg-dir": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-          "requires": {
-            "find-up": "^5.0.0"
-          }
-        }
       }
     },
     "abab": {
@@ -37815,232 +37595,6 @@
         "path-type": "^4.0.0"
       }
     },
-    "directus": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/directus/-/directus-9.1.2.tgz",
-      "integrity": "sha512-vhOcYsRlXe45RTI1o+D3mc4EAb819a/fH94P9vklUEHqIu/AeD9bMwD1LRAQnUI5SvzCaLI788SMiLBrnws3Aw==",
-      "requires": {
-        "@aws-sdk/client-ses": "^3.40.0",
-        "@directus/app": "9.1.2",
-        "@directus/drive": "9.1.2",
-        "@directus/drive-azure": "9.1.2",
-        "@directus/drive-gcs": "9.1.2",
-        "@directus/drive-s3": "9.1.2",
-        "@directus/extensions-sdk": "9.1.2",
-        "@directus/format-title": "9.1.2",
-        "@directus/schema": "9.1.2",
-        "@directus/shared": "9.1.2",
-        "@directus/specs": "9.1.2",
-        "@godaddy/terminus": "^4.9.0",
-        "@keyv/redis": "^2.1.2",
-        "@rollup/plugin-alias": "^3.1.2",
-        "@rollup/plugin-virtual": "^2.0.3",
-        "argon2": "^0.28.2",
-        "async": "^3.2.0",
-        "async-mutex": "^0.3.1",
-        "atob": "^2.1.2",
-        "axios": "^0.24.0",
-        "busboy": "^0.3.1",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.1",
-        "commander": "^8.0.0",
-        "connect-memcached": "^1.0.0",
-        "connect-redis": "^6.0.0",
-        "connect-session-knex": "^2.1.0",
-        "cookie-parser": "^1.4.5",
-        "cors": "^2.8.5",
-        "csv-parser": "^3.0.0",
-        "date-fns": "^2.22.1",
-        "deep-diff": "^1.0.2",
-        "deep-map": "^2.0.0",
-        "destroy": "^1.0.4",
-        "dotenv": "^10.0.0",
-        "eventemitter2": "^6.4.3",
-        "execa": "^5.1.1",
-        "exifr": "^7.1.2",
-        "express": "^4.17.1",
-        "flat": "^5.0.2",
-        "fs-extra": "^10.0.0",
-        "graphql": "^15.5.0",
-        "graphql-compose": "^9.0.1",
-        "inquirer": "^8.1.1",
-        "ioredis": "^4.27.6",
-        "joi": "^17.3.0",
-        "js-yaml": "^4.1.0",
-        "js2xmlparser": "^4.0.1",
-        "json2csv": "^5.0.3",
-        "jsonwebtoken": "^8.5.1",
-        "keyv": "^4.0.3",
-        "keyv-memcache": "^1.2.5",
-        "knex": "^0.95.11",
-        "knex-schema-inspector": "1.6.4",
-        "ldapjs": "^2.3.1",
-        "liquidjs": "^9.25.0",
-        "lodash": "^4.17.21",
-        "macos-release": "^2.4.1",
-        "marked": "^4.0.3",
-        "memcached": "^2.2.2",
-        "mime-types": "^2.1.31",
-        "ms": "^2.1.3",
-        "mysql": "^2.18.1",
-        "nanoid": "^3.1.23",
-        "node-cron": "^3.0.0",
-        "node-machine-id": "^1.1.12",
-        "nodemailer": "^6.6.1",
-        "nodemailer-mailgun-transport": "^2.1.3",
-        "object-hash": "^2.2.0",
-        "openapi3-ts": "^2.0.0",
-        "openid-client": "^5.0.0",
-        "ora": "^5.4.0",
-        "otplib": "^12.0.1",
-        "pg": "^8.6.0",
-        "pino": "6.13.3",
-        "pino-colada": "^2.1.0",
-        "pino-http": "5.8.0",
-        "qs": "^6.9.4",
-        "rate-limiter-flexible": "^2.2.2",
-        "resolve-cwd": "^3.0.0",
-        "rollup": "^2.52.1",
-        "sanitize-html": "^2.6.0",
-        "sharp": "^0.29.0",
-        "sqlite3": "^5.0.2",
-        "stream-json": "^1.7.1",
-        "supertest": "^6.1.6",
-        "tedious": "^13.0.0",
-        "update-check": "^1.5.4",
-        "uuid": "^8.3.2",
-        "uuid-validate": "0.0.3",
-        "wellknown": "^0.5.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "axios": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-          "requires": {
-            "follow-redirects": "^1.14.4"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        },
-        "knex-schema-inspector": {
-          "version": "1.6.4",
-          "resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.4.tgz",
-          "integrity": "sha512-OCmicnMAaC109heNx79S3aYzTK4B9n+8uQ8z4ZBdqr8DN2E+xP9hLMpxfZFZkHMjilSQy13PgzfgvbgFgRNGSg==",
-          "requires": {
-            "lodash.flatten": "^4.4.0",
-            "lodash.isnil": "^4.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "pino": {
-          "version": "6.13.3",
-          "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
-          "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
-          "requires": {
-            "fast-redact": "^3.0.0",
-            "fast-safe-stringify": "^2.0.8",
-            "fastify-warning": "^0.2.0",
-            "flatstr": "^1.0.12",
-            "pino-std-serializers": "^3.1.0",
-            "quick-format-unescaped": "^4.0.3",
-            "sonic-boom": "^1.0.2"
-          },
-          "dependencies": {
-            "pino-std-serializers": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-              "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
-            }
-          }
-        },
-        "pino-http": {
-          "version": "5.8.0",
-          "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.8.0.tgz",
-          "integrity": "sha512-YwXiyRb9y0WCD1P9PcxuJuh3Dc5qmXde/paJE86UGYRdiFOi828hR9iUGmk5gaw6NBT9gLtKANOHFimvh19U5w==",
-          "requires": {
-            "fast-url-parser": "^1.1.3",
-            "pino": "^6.13.0",
-            "pino-std-serializers": "^4.0.0"
-          }
-        },
-        "qs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-          "requires": {
-            "side-channel": "^1.0.4"
-          }
-        },
-        "sonic-boom": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-          "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-          "requires": {
-            "atomic-sleep": "^1.0.0",
-            "flatstr": "^1.0.12"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -38102,21 +37656,6 @@
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
-        }
-      }
-    },
-    "domhandler": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
-      "integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
-      "requires": {
-        "domelementtype": "^2.2.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
         }
       }
     },
@@ -40512,44 +40051,6 @@
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
       "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
       "dev": true
-    },
-    "htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "dom-serializer": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.2.0",
-            "entities": "^2.0.0"
-          }
-        },
-        "domelementtype": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
-        },
-        "domutils": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-          "requires": {
-            "dom-serializer": "^1.0.1",
-            "domelementtype": "^2.2.0",
-            "domhandler": "^4.2.0"
-          }
-        }
-      }
     },
     "http-assert": {
       "version": "1.5.0",
@@ -43139,15 +42640,6 @@
         }
       }
     },
-    "knex-schema-inspector": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/knex-schema-inspector/-/knex-schema-inspector-1.6.6.tgz",
-      "integrity": "sha512-tiG35ttP0g/EwXTb2+vSRYK3++7eetaaojauIHjXwocdQqsRNNhEfouCMdmE+WcaMmM7dm+sJhYD5QHh2lVmxA==",
-      "requires": {
-        "lodash.flatten": "^4.4.0",
-        "lodash.isnil": "^4.0.0"
-      }
-    },
     "koa": {
       "version": "2.13.4",
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.13.4.tgz",
@@ -43952,11 +43444,6 @@
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
       "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
       "requires": {}
-    },
-    "marked": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.6.tgz",
-      "integrity": "sha512-+H0bTf8DM8zLuFBUm/2VklxaCrwlBFgoJzHJcMZCnZ9cPgsllHwKpL6TPLdDeA38yPluMuVKOL1hO5w6HmG5Mg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -45894,11 +45381,6 @@
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
       "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
     },
-    "parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
-    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -45925,14 +45407,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "path-is-network-drive": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/path-is-network-drive/-/path-is-network-drive-1.0.10.tgz",
-      "integrity": "sha512-D6kJYPUSKGZBpTM2nv10sOWNdC056p4JDx0y7ARe6gop0aXXm5G86Gn/SyKvaf0Ce8c9Guctf+J+qoFmzuhDQg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -45942,14 +45416,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "path-strip-sep": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-strip-sep/-/path-strip-sep-1.0.7.tgz",
-      "integrity": "sha512-9xDVZPblHde4lTuTDnwqBKr9LTbPZW+Iae63ho500+BpEiZe3X6wvLInHgbB6FSMtwCTvztljw3k2zcNDNESzg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -48722,58 +48188,6 @@
       "dev": true,
       "requires": {}
     },
-    "rollup-plugin-typescript2": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.1.tgz",
-      "integrity": "sha512-sklqXuQwQX+stKi4kDfEkneVESPi3YM/2S899vfRdF9Yi40vcC50Oq4A4cSZJNXsAQE/UsBZl5fAOsBLziKmjw==",
-      "requires": {
-        "@rollup/pluginutils": "^4.1.0",
-        "@yarn-tool/resolve-package": "^1.0.36",
-        "find-cache-dir": "^3.3.1",
-        "fs-extra": "8.1.0",
-        "resolve": "1.20.0",
-        "tslib": "2.2.0"
-      },
-      "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
-          "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
-          "requires": {
-            "estree-walker": "^2.0.1",
-            "picomatch": "^2.2.2"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-        }
-      }
-    },
     "rollup-plugin-vue": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz",
@@ -48865,31 +48279,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sanitize-html": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.6.0.tgz",
-      "integrity": "sha512-qc+NqTeaOi/QVAVs5gOY9tqIVk4r1pcUbx1Q2N1a609Os3TNlm85zll2d8g8m/RM6RWg9llir0SpAcePQVIC1w==",
-      "requires": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^6.0.0",
-        "is-plain-object": "^5.0.0",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "is-plain-object": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-        }
-      }
     },
     "sax": {
       "version": "1.2.1",
@@ -50643,21 +50032,6 @@
         }
       }
     },
-    "ts-toolbelt": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
-      "peer": true
-    },
-    "ts-type": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-2.0.3.tgz",
-      "integrity": "sha512-Cc2kgkUwmCK/h2m/sVbr2piqOGE+Hs4qAgJ7CiI4OSMJFWorE6f6yoisjSBE5izGb2/VZnHSN2CcOQR6/Yfazw==",
-      "requires": {
-        "tslib": "^2.3.1",
-        "typedarray-dts": "^1.0.0"
-      }
-    },
     "tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -50797,11 +50171,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
-    "typedarray-dts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
-      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA=="
-    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -50892,17 +50261,6 @@
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true
-    },
-    "upath2": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/upath2/-/upath2-3.1.10.tgz",
-      "integrity": "sha512-7ph3GzTaVbQX+oIoMsGtM+9BAWQr+6Mn28TJKPu28+yGpZ+J4am590CPDBlDG0zyuo9T9T7o21ciqNzwIp/q0A==",
-      "requires": {
-        "lodash": "^4.17.21",
-        "path-is-network-drive": "^1.0.10",
-        "path-strip-sep": "^1.0.7",
-        "tslib": "^2.3.1"
-      }
     },
     "update-check": {
       "version": "1.5.4",

--- a/services/api/src/lib/directus-adapter.ts
+++ b/services/api/src/lib/directus-adapter.ts
@@ -517,7 +517,9 @@ export default class DirectusAdapter {
   private async findPackTemplates(query: ItemQuery<DirectusPackTemplate> = {}) {
     const defaultQuery: ItemQuery<DirectusPackTemplate> = {
       filter: {
-        status: DirectusStatus.Published,
+        status: {
+          _eq: DirectusStatus.Published,
+        },
       },
       limit: -1,
       fields: ['*.*'],
@@ -534,7 +536,9 @@ export default class DirectusAdapter {
   ) {
     const defaultQuery: ItemQuery<DirectusCollectibleTemplate> = {
       filter: {
-        status: DirectusStatus.Published,
+        status: {
+          _eq: DirectusStatus.Published,
+        },
       },
       limit: -1,
       fields: ['*.*'],
@@ -549,7 +553,9 @@ export default class DirectusAdapter {
   private async findCollections(query: ItemQuery<DirectusCollection> = {}) {
     const defaultQuery: ItemQuery<DirectusCollection> = {
       filter: {
-        status: DirectusStatus.Published,
+        status: {
+          _eq: DirectusStatus.Published,
+        },
       },
       limit: -1,
       fields: ['*.*'],
@@ -564,7 +570,9 @@ export default class DirectusAdapter {
   private async findSets(query: ItemQuery<DirectusSet> = {}) {
     const defaultQuery: ItemQuery<DirectusSet> = {
       filter: {
-        status: DirectusStatus.Published,
+        status: {
+          _eq: DirectusStatus.Published,
+        },
       },
       limit: -1,
       fields: ['*.*'],
@@ -600,7 +608,9 @@ export default class DirectusAdapter {
       deep: {
         translations: {
           _filter: {
-            languages_code: locale,
+            languages_code: {
+              _eq: locale,
+            },
           },
         },
       },
@@ -627,7 +637,9 @@ export default class DirectusAdapter {
     const response = await this.findPackTemplates({
       limit: 1,
       filter: {
-        status: DirectusStatus.Published,
+        status: {
+          _eq: DirectusStatus.Published,
+        },
         ...filter,
       },
       deep: {
@@ -651,7 +663,9 @@ export default class DirectusAdapter {
   ) {
     const response = await this.findCollectibleTemplates({
       filter: {
-        status: DirectusStatus.Published,
+        status: {
+          _eq: DirectusStatus.Published,
+        },
         ...filter,
       },
       limit,
@@ -716,13 +730,17 @@ export default class DirectusAdapter {
       deep: {
         translations: {
           _filter: {
-            languages_code: locale,
+            languages_code: {
+              _eq: locale,
+            },
           },
         },
         sets: {
           translations: {
             _filter: {
-              languages_code: locale,
+              languages_code: {
+                _eq: locale,
+              },
             },
           },
         },
@@ -747,8 +765,12 @@ export default class DirectusAdapter {
     const response = await this.findCollections({
       limit: 1,
       filter: {
-        status: DirectusStatus.Published,
-        slug,
+        status: {
+          _eq: DirectusStatus.Published,
+        },
+        slug: {
+          _eq: slug,
+        },
       },
       fields: [
         'collection_image',
@@ -765,13 +787,17 @@ export default class DirectusAdapter {
       deep: {
         translations: {
           _filter: {
-            languages_code: locale,
+            languages_code: {
+              _eq: locale,
+            },
           },
         },
         sets: {
           translations: {
             _filter: {
-              languages_code: locale,
+              languages_code: {
+                _eq: locale,
+              },
             },
           },
         },
@@ -786,8 +812,12 @@ export default class DirectusAdapter {
   async findSetBySlug(slug: string, locale = DEFAULT_LOCALE) {
     const response = await this.findSets({
       filter: {
-        status: DirectusStatus.Published,
-        slug,
+        status: {
+          _eq: DirectusStatus.Published,
+        },
+        slug: {
+          _eq: slug,
+        },
       },
       fields: [
         'collection.collection_image',
@@ -805,13 +835,17 @@ export default class DirectusAdapter {
       deep: {
         translations: {
           _filter: {
-            languages_code: locale,
+            languages_code: {
+              _eq: locale,
+            },
           },
         },
         sets: {
           translations: {
             _filter: {
-              languages_code: locale,
+              languages_code: {
+                _eq: locale,
+              },
             },
           },
         },
@@ -833,17 +867,23 @@ export default class DirectusAdapter {
         deep: {
           featured_pack: {
             _filter: {
-              status: DirectusStatus.Published,
+              status: {
+                _eq: DirectusStatus.Published,
+              },
             },
           },
           upcoming_packs: {
             _filter: {
-              status: DirectusStatus.Published,
+              status: {
+                _eq: DirectusStatus.Published,
+              },
             },
           },
           notable_collectibles: {
             _filter: {
-              status: DirectusStatus.Published,
+              status: {
+                _eq: DirectusStatus.Published,
+              },
             },
           },
         },

--- a/services/api/src/modules/collectibles/collectibles.service.ts
+++ b/services/api/src/modules/collectibles/collectibles.service.ts
@@ -423,8 +423,8 @@ export default class CollectiblesService {
 
     const filter: ItemFilter = {}
     if (templateIds.length > 0) filter.id = { _in: templateIds }
-    if (setId) filter.set = { id: setId }
-    if (collectionId) filter.collection = { id: collectionId }
+    if (setId) filter.set = { id: { _eq: setId } }
+    if (collectionId) filter.collection = { id: { _eq: collectionId } }
 
     const { collectibles: templates } = await this.cms.findAllCollectibles(
       locale,

--- a/services/api/src/modules/packs/packs.service.ts
+++ b/services/api/src/modules/packs/packs.service.ts
@@ -436,7 +436,7 @@ export default class PacksService {
     invariant(pack.collectibles.length > 0, 'pack has no collectibles')
 
     const packTemplate = await this.cms.findPack(
-      { id: pack.templateId },
+      { id: { _eq: pack.templateId } },
       locale
     )
     invariant(packTemplate, 'pack template missing in cms')
@@ -517,7 +517,10 @@ export default class PacksService {
       return null
     }
 
-    const template = await this.cms.findPack({ id: pack.templateId }, locale)
+    const template = await this.cms.findPack(
+      { id: { _eq: pack.templateId } },
+      locale
+    )
 
     if (!template) {
       throw new Error(`pack template with ID ${pack.templateId} not found`)
@@ -535,7 +538,7 @@ export default class PacksService {
 
     const template = await this.cms.findPack(
       {
-        id: pack.templateId,
+        id: { _eq: pack.templateId },
       },
       locale
     )
@@ -553,7 +556,7 @@ export default class PacksService {
     templateId: string,
     trx?: Transaction
   ): Promise<PackWithId> {
-    const template = await this.cms.findPack({ id: templateId })
+    const template = await this.cms.findPack({ id: { _eq: templateId } })
 
     userInvariant(template, 'pack template not found', 404)
 
@@ -1049,7 +1052,9 @@ export default class PacksService {
       filter: {
         _and: [
           {
-            type: PackType.Auction,
+            type: {
+              _eq: PackType.Auction,
+            },
           },
           // Shouldn't need every historical auction
           {
@@ -1088,7 +1093,11 @@ export default class PacksService {
         )
 
         const packTemplate = await this.cms.findPack(
-          { id: pack.templateId },
+          {
+            id: {
+              _eq: pack.templateId,
+            },
+          },
           pack.activeBid.userAccount.locale
         )
         invariant(packTemplate, 'packTemplate not found')
@@ -1150,7 +1159,7 @@ export default class PacksService {
         )
 
         const packTemplate = await this.cms.findPack(
-          { id: pack.templateId },
+          { id: { _eq: pack.templateId } },
           pack.activeBid.userAccount.locale
         )
         invariant(packTemplate, 'packTemplate not found')
@@ -1225,7 +1234,7 @@ export default class PacksService {
           )
 
           const packTemplate = await this.cms.findPack(
-            { id: pack.templateId },
+            { id: { _eq: pack.templateId } },
             selectedBid.userAccount.locale
           )
           invariant(packTemplate, 'packTemplate not found')


### PR DESCRIPTION
Due to issues with the latest version of Directus, downgrade until the issues have been resolved.

Also follows the suggested filter format and use `_eq` for basic comparisons.