### PR TITLE
Update Readme to point to correct url for CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ in the `docker-compose.yml` file.
 The CMS key needs to be added to the admin user created by Directus.
 Otherwise, the API cannot authenticate even though its CMS key matches.
 
-- Visit http://localhost:8085
+- Visit http://localhost:8055
 - Authenticate with the CMS admin email & password
 - Go to the [user directory](http://localhost:8085/admin/users)
 - Click the admin user and enter the CMS key into the "Token" field

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ in the `docker-compose.yml` file.
 The CMS key needs to be added to the admin user created by Directus.
 Otherwise, the API cannot authenticate even though its CMS key matches.
 
-- Visit http://localhost:3001
+- Visit http://localhost:8085
 - Authenticate with the CMS admin email & password
-- Go to the [user directory](http://localhost:3001/admin/users)
+- Go to the [user directory](http://localhost:8085/admin/users)
 - Click the admin user and enter the CMS key into the "Token" field
 - Click the green check mark in the upper right corner
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Otherwise, the API cannot authenticate even though its CMS key matches.
 
 - Visit http://localhost:8055
 - Authenticate with the CMS admin email & password
-- Go to the [user directory](http://localhost:8085/admin/users)
+- Go to the [user directory](http://localhost:8055/admin/users)
 - Click the admin user and enter the CMS key into the "Token" field
 - Click the green check mark in the upper right corner
 


### PR DESCRIPTION
Out of the box, the CMS is located at `http://localhost:8085` not `http://localhost:3001`. Just a small change to fix this.