### PR TITLE
tailwind.config.js requires non-node protocol

### DIFF
--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -3,7 +3,7 @@ const flattenColorPalette =
   require('tailwindcss/lib/util/flattenColorPalette').default
 const plugin = require('tailwindcss/plugin')
 const { createGlobPatternsForDependencies } = require('@nrwl/react/tailwind')
-const path = require('node:path')
+const path = require('path')
 
 module.exports = {
   // Keep JIT disabled for now. Enabling it will break the custom font loading.


### PR DESCRIPTION
Very minor fix and only affects the VS Code Tailwind extension. Basically, it cannot parse `node:` imports.