### PR TITLE
Use specific version for github action

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -60,7 +60,7 @@ jobs:
           mv /tmp/.buildx-cache-${{ matrix.app }}-new /tmp/.buildx-cache-${{ matrix.app }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0.3.0
         with:
           version: '290.0.1'
           service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
This will fix warnings like:

> google-github-actions/setup-gcloud is pinned at HEAD. We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from: uses: 'google-github-actions/setup-gcloud@master' to: uses: 'google-github-actions/setup-gcloud@v0' Alternatively, you can pin to any git tag or git SHA in the repository.
