### PR TITLE
Add marketplace auction page using fake data

### DIFF
--- a/apps/web/src/clients/api-client.ts
+++ b/apps/web/src/clients/api-client.ts
@@ -37,6 +37,7 @@ import {
   PackId,
   PacksByOwner,
   PacksByOwnerQuery,
+  PackStatus,
   PackWithCollectibles,
   PackWithId,
   Payment,
@@ -437,6 +438,119 @@ export class ApiClient {
         },
       })
       .json<Homepage>()
+  }
+  //#endregion
+
+  //#region CollectibleAuction
+  async getCollectibleAuction(collectibleAuctionId: string) {
+    // TODO: Call API
+    const today = new Date()
+    const lastWeek = new Date(today)
+    lastWeek.setDate(lastWeek.getDate() - 1)
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+    const tomorrow = new Date(today)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const threeDaysFromNow = new Date(today)
+    threeDaysFromNow.setDate(threeDaysFromNow.getDate() + 3)
+    const upcoming = {
+      id: '6cb0fb67-51f3-42dc-b288-97a2d7759ef6',
+      collectibleId: '8176f4c3-ca5e-4dfc-a195-a86a562b74de',
+      reservePrice: 0,
+      startAt: tomorrow.toISOString(),
+      endAt: threeDaysFromNow.toISOString(),
+      status: PackStatus.Upcoming,
+    }
+    const active = {
+      id: '88c1e083-91d0-4c96-828e-cca4d5d01572',
+      collectibleId: '3f214cd7-ff89-43f2-a768-580a3b85780d',
+      reservePrice: 0,
+      startAt: yesterday.toISOString(),
+      endAt: threeDaysFromNow.toISOString(),
+      status: PackStatus.Active,
+    }
+    const ended = {
+      id: 'c62b78b0-149d-4b82-8df2-c2b8298923a7',
+      collectibleId: 'e8ad7bbd-b2bf-4f2c-a925-e412cad5f521',
+      reservePrice: 0,
+      startAt: lastWeek.toISOString(),
+      endAt: yesterday.toISOString(),
+      status: PackStatus.Expired,
+    }
+    const collectibleAuctions = [upcoming, active, ended]
+    return collectibleAuctions.find((ca) => ca.id === collectibleAuctionId)
+  }
+
+  async getCollectibleAuctionBids(collectibleAuctionId: string) {
+    const today = new Date()
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+    const activeBid = {
+      amount: 700,
+      externalId: 'oa8RLiV8U8bGhVHI23iNrZHOU392',
+      username: 'davidjmurphyjr',
+      createdAt: yesterday.toISOString(),
+      collectibleAuctionId: '88c1e083-91d0-4c96-828e-cca4d5d01572',
+    }
+    const collectibleAuctionBids = [activeBid]
+    return collectibleAuctionBids.filter(
+      (a) => a.collectibleAuctionId === collectibleAuctionId
+    )
+  }
+
+  async getCollectiblesById(collectibleId: string) {
+    const upcoming = {
+      id: '8176f4c3-ca5e-4dfc-a195-a86a562b74de',
+      templateId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      ownerExternalId: '52767fe4-2257-4bf3-86a3-dd756c6e7d2c',
+    }
+    const active = {
+      id: '3f214cd7-ff89-43f2-a768-580a3b85780d',
+      templateId: 'f085fff1-b9df-4ff0-810b-71d75997f518',
+      ownerExternalId: '52767fe4-2257-4bf3-86a3-dd756c6e7d2c',
+    }
+    const ended = {
+      id: 'e8ad7bbd-b2bf-4f2c-a925-e412cad5f521',
+      templateId: '15486e91-6e0e-4883-9ea5-90d60f17413b',
+      ownerExternalId: '52767fe4-2257-4bf3-86a3-dd756c6e7d2c',
+    }
+    const collectibles = [upcoming, active, ended]
+    return collectibles.find((c) => c.id === collectibleId)
+  }
+
+  async getCollectibleTemplate(collectibleTemplateId: string) {
+    const upcoming = {
+      id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      image:
+        'http://localhost:8055/assets/c3ec9cc0-ac80-4edc-bfeb-6ad74e40bf78',
+      title: 'pack-dm title',
+      subtitle: 'pack-dm subtitle',
+      body: 'pack-dm body',
+      available: 1,
+      total: 1,
+    }
+    const active = {
+      id: 'f085fff1-b9df-4ff0-810b-71d75997f518',
+      image:
+        'http://localhost:8055/assets/c3ec9cc0-ac80-4edc-bfeb-6ad74e40bf78',
+      title: 'pack-dm title',
+      subtitle: 'pack-dm subtitle',
+      body: 'pack-dm body',
+      available: 1,
+      total: 1,
+    }
+    const ended = {
+      id: '15486e91-6e0e-4883-9ea5-90d60f17413b',
+      image:
+        'http://localhost:8055/assets/c3ec9cc0-ac80-4edc-bfeb-6ad74e40bf78',
+      title: 'pack-dm title',
+      subtitle: 'pack-dm subtitle',
+      body: 'pack-dm body',
+      available: 1,
+      total: 1,
+    }
+    const CollectibleTemplates = [upcoming, active, ended]
+    return CollectibleTemplates.find((ct) => ct.id === collectibleTemplateId)
   }
   //#endregion
 }

--- a/apps/web/src/pages/marketplace/auctions/[collectibleAuctionId].tsx
+++ b/apps/web/src/pages/marketplace/auctions/[collectibleAuctionId].tsx
@@ -1,0 +1,150 @@
+import { PackAuction, PackType, PublishedPack } from '@algomart/schemas'
+import { GetServerSideProps } from 'next'
+import useTranslation from 'next-translate/useTranslation'
+import { useEffect } from 'react'
+
+import { ApiClient } from '@/clients/api-client'
+import { Analytics } from '@/clients/firebase-analytics'
+import { useRedemption } from '@/contexts/redemption-context'
+import DefaultLayout from '@/layouts/default-layout'
+import {
+  getAuthenticatedUser,
+  getProfileImageForUser,
+} from '@/services/api/auth-service'
+import ReleaseTemplate from '@/templates/release-template'
+import { isAfterNow } from '@/utils/date-time'
+
+interface ReleasePageProps {
+  avatars: { [key: string]: string | null }
+  disallowBuyOrClaim: boolean | null
+  isHighestBidder: boolean | null
+  isOutbid: boolean | null
+  isOwner: boolean | null
+  isWinningBidder: boolean | null
+  packAuction: PackAuction | null
+  packTemplate: PublishedPack
+}
+
+export default function ReleasePage({
+  avatars,
+  disallowBuyOrClaim,
+  isHighestBidder,
+  isOutbid,
+  isOwner,
+  isWinningBidder,
+  packAuction,
+  packTemplate,
+}: ReleasePageProps) {
+  const { setRedeemable } = useRedemption()
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    Analytics.instance.viewItem({
+      itemName: packTemplate.title,
+      value: packAuction?.activeBid?.amount ?? packTemplate.price,
+    })
+  }, [packAuction, packTemplate])
+
+  const handleClaimNFT = async (): Promise<{ packId: string } | string> => {
+    // TODO: implement for marketplace auction
+    return { packId: packAuction.packId }
+  }
+
+  return (
+    <DefaultLayout
+      pageTitle={t('common:pageTitles.Release', { name: packTemplate.title })}
+      noPanel
+    >
+      <ReleaseTemplate
+        avatars={avatars}
+        disallowBuyOrClaim={disallowBuyOrClaim}
+        handleClaimNFT={handleClaimNFT}
+        isHighestBidder={isHighestBidder}
+        isOutbid={isOutbid}
+        isOwner={isOwner}
+        isWinningBidder={isWinningBidder}
+        packAuction={packAuction}
+        packTemplate={packTemplate}
+      />
+    </DefaultLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const user = await getAuthenticatedUser(context)
+
+  const collectibleAuctionId = context?.params?.collectibleAuctionId as string
+  const collectibleAuction = await ApiClient.instance.getCollectibleAuction(
+    collectibleAuctionId
+  )
+
+  if (!collectibleAuction) {
+    return {
+      notFound: true,
+    }
+  }
+
+  const avatars: { [key: string]: string | null } = {}
+  let isHighestBidder = null,
+    isOwner = null,
+    isWinningBidder = null,
+    isOutbid = null
+
+  const collectible = await ApiClient.instance.getCollectiblesById(
+    collectibleAuction.collectibleId
+  )
+
+  const collectibleAuctionBids =
+    await ApiClient.instance.getCollectibleAuctionBids(collectibleAuctionId)
+  const activeBid = collectibleAuctionBids[0]
+  const collectibleTemplate = await ApiClient.instance.getCollectibleTemplate(
+    collectible.templateId
+  )
+
+  // Get bidder avatars
+  await Promise.all(
+    collectibleAuctionBids.map(async ({ externalId }) => {
+      avatars[externalId] = await getProfileImageForUser(externalId)
+    })
+  )
+
+  // Configure auction statuses
+  if (user) {
+    const isClosed = !!(
+      collectibleAuction.endAt &&
+      !isAfterNow(new Date(collectibleAuction.endAt))
+    )
+    const userHasBids = collectibleAuctionBids?.some(
+      (b) => b.externalId === user.externalId
+    )
+
+    isHighestBidder = activeBid?.externalId === user.externalId
+    isOwner = collectible.ownerExternalId === user.externalId
+    isWinningBidder = isHighestBidder && isClosed
+    isOutbid = !isHighestBidder && userHasBids
+  }
+
+  return {
+    props: {
+      avatars,
+      isHighestBidder,
+      isOutbid,
+      isOwner,
+      isWinningBidder,
+      packAuction: {
+        ...collectibleAuction,
+        bids: collectibleAuctionBids,
+        ownerExternalId: collectible.ownerExternalId,
+      },
+      packTemplate: {
+        type: 'auction',
+        auctionUntil: collectibleAuction.endAt,
+        releasedAt: collectibleAuction.startAt,
+        price: collectibleAuction.reservePrice,
+        status: collectibleAuction.status,
+        templateId: collectibleTemplate.id,
+        ...collectibleTemplate,
+      },
+    },
+  }
+}


### PR DESCRIPTION
[Issue](https://github.com/deptagency/algomart/issues/212)

[Figma](https://www.figma.com/file/hkoiAU61jBPuJy0jESAXrl/AlgoMart?node-id=2504%3A7117)


This PR
- Adds some fake API calls to support marketplace auctions
- Maps collectibleAuction data to the packAuction format for use with the release-template.

I'm pretty sure we want to wire up the real API before merging this, hence the draft status and do not merge tag.

I think it's okay that the marketplace auction page uses the release-template, violating the template per page pattern, because the draft marketplace auction Figmas are essentially copies of the pack auction Figmas. Once design finalizes the Figmas and we understand how pack and marketplaces auctions are the same and how they differ, we can refactor to capture the commonality. Alternatively, if two pages sharing one template feels dirty, I could make a copy of release-template and rename it marketplace-auction-template and throw a TODO on it. 

#### URLs to the fake page
http://localhost:3000/marketplace/auctions/6cb0fb67-51f3-42dc-b288-97a2d7759ef6
http://localhost:3000/marketplace/auctions/c62b78b0-149d-4b82-8df2-c2b8298923a7
http://localhost:3000/marketplace/auctions/88c1e083-91d0-4c96-828e-cca4d5d01572

#### Screenshots 
![image](https://user-images.githubusercontent.com/3670577/151404901-d05a4f69-7b88-4643-a2b3-73c45fc3b794.png)
![image](https://user-images.githubusercontent.com/3670577/151404912-3246e04b-a237-4a98-83f4-4512d1094660.png)
![image](https://user-images.githubusercontent.com/3670577/151404923-ab9736f5-7658-42b5-8caa-1c69c3115600.png)
