### PR TITLE
Readme typos, clarity. Better directus executor failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This software is in a pre-release state. This means while we strive to keep it s
 - [Circle][circle] account for taking payments
 - [SendGrid][sendgrid] for sending email notifications
 - [Firebase][firebase] account for authentication
+- [Pinata][pinata] account for storing NFTs
 - (optional) [Google Cloud Platform][gcp] account for hosting
 - (optional) Install the [Nx CLI][nx cli] for ease of development: `npm i -g nx`
 
@@ -163,6 +164,7 @@ npm run test:api -- --watch
 [sendgrid]: https://sendgrid.com
 [web]: apps/web
 [nx cli]: https://nx.dev/using-nx/nx-cli#nx-cli
+[pinata]: https://www.pinata.cloud/
 
 ## 🚢 Deployment
 

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -166,13 +166,7 @@ The homepage of the provided UI depicts a featured Pack, which takes prominence 
 
 ## Updating the data model
 
-To update the data model you can start by locally using the Directus UI. But to ensure other developers can apply those changes you will need to write a migration file based on [knex](https://knexjs.org/). See the existing migration files for examples.
+To update the data model you can start by locally using the Directus UI. But to ensure other developers can apply those changes you will need to export the data model to a snapshot file.
 
-Running `npm run bootstrap` will apply new migrations. Additionally, the `package.json` contains other migration scripts (up, down, rollback, and latest) in case they're needed.
-
-## Importing & Exporting Data
-
-Data may be exported from the CMS via `npm run export` and loaded via `npm run import`. This includes Rarities, Packs, NFT Templates, Sets, Collections and asset files (typically images & videos). Make sure your CMS server is running before running either script.
-
-`npm run export` — This will export data to `scripts/export/`
-`npm run import` — Import data from `scripts/export/` (this will not overwrite any records)
+`nx export cms` - This exports the CMS data model to `snapshot.yml`
+`nx import cms` - This imports from `snapshot.yml` to your CMS

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -6,7 +6,7 @@ The purpose of the CMS is to provide content authors the ability to create and m
 
 ## Get started
 
-Once the environment variables have been added to the `.env` file, you'll want to create a new Postgres database with the name specified in the `DB_CONNECTION_STRING` in the `.env` file. You'll also want to set the `ADMIN_EMAIL` and `ADMIN_PASSWORD` values for the initial CMS admin user.
+Once the environment variables have been added to the `.env` file, you'll want to create a new Postgres database with the name specified in the `DB_CONNECTION_STRING` in the `.env` file and create an appropriate schema for `DB_SEARCH_PATH`. You'll also want to set the `ADMIN_EMAIL` and `ADMIN_PASSWORD` values for the initial CMS admin user.
 
 Run the bootstrap and import commands via Nx:
 
@@ -115,7 +115,7 @@ Note that once a Pack Template record is published, many of its fields cannot be
 
 ## Sets
 
-Sets are an optional mechanism to group NFTs in a way that can incentivize an end-user to collect all of the NFTs assigned to a a Set. For example, let's imagine we are distributing football card NFTs. A Set might be all of the NFTs for a player on a given team in the 2022 season.
+Sets are an optional mechanism to group NFTs in a way that can incentivize an end-user to collect all of the NFTs assigned to a Set. For example, let's imagine we are distributing football card NFTs. A Set might be all of the NFTs for a player on a given team in the 2022 season.
 
 Note that once Set record is published, many of its fields cannot be edited. This is to maintain integrity of the acquisition incentive. A Set has a number of configurable fields:
 
@@ -127,7 +127,7 @@ Note that once Set record is published, many of its fields cannot be edited. Thi
 
 ## Collections
 
-Not to be confused with Directus' "Collection" nomenclature. Within this platform, Collections are an optional mechanism to group Sets and/or individual NFTs in a way that can incentivize an end-user to collect all of the NFTs assigned to a a Collection, or all of the NFTs in the Sets assigned to the Collection. For example, let's revisit the football card NFTs scenario described above. A Collection might represent all of the football teams in a league for the 2022 season. Each Set (again, representing a team), would contain NFTs for each player on a given team in the 2022 season. So in essence, a user who has collected all NFTs in every Set of a Collection has effectively collected all of the NFTs for each player in the 2022 football league.
+Not to be confused with Directus' "Collection" nomenclature. Within this platform, Collections are an optional mechanism to group Sets and/or individual NFTs in a way that can incentivize an end-user to collect all of the NFTs assigned to a Collection, or all of the NFTs in the Sets assigned to the Collection. For example, let's revisit the football card NFTs scenario described above. A Collection might represent all of the football teams in a league for the 2022 season. Each Set (again, representing a team), would contain NFTs for each player on a given team in the 2022 season. So in essence, a user who has collected all NFTs in every Set of a Collection has effectively collected all of the NFTs for each player in the 2022 football league.
 
 Collections don't have to contain Sets. They can also just contain individual NFTs. They also contain Sets AND individual NFTs.
 
@@ -172,7 +172,7 @@ Running `npm run bootstrap` will apply new migrations. Additionally, the `packag
 
 ## Importing & Exporting Data
 
-Data may be exported from the CMS via `npm run export` and loaded via `npm run import`. This includes Rarities, Packs, NFT Templates, Sets, Collections and asset files (typically images & videos). MNake sure your CMS server is running before running either script.
+Data may be exported from the CMS via `npm run export` and loaded via `npm run import`. This includes Rarities, Packs, NFT Templates, Sets, Collections and asset files (typically images & videos). Make sure your CMS server is running before running either script.
 
 `npm run export` — This will export data to `scripts/export/`
 `npm run import` — Import data from `scripts/export/` (this will not overwrite any records)

--- a/tools/executors/directus/impl.js
+++ b/tools/executors/directus/impl.js
@@ -193,7 +193,7 @@ function directusExecutor(options, context) {
           return [4 /*yield*/, runAction(options, context)]
         case 1:
           _a.sent()
-          return [2 /*return*/]
+          return [2 /*return*/, { success: true }]
       }
     })
   })

--- a/tools/executors/directus/impl.js
+++ b/tools/executors/directus/impl.js
@@ -177,6 +177,7 @@ function runAction(options, context) {
           directus.on('exit', function (code) {
             if (code !== 0) {
               reject(code)
+              return
             }
             resolve(true)
           })

--- a/tools/executors/directus/impl.js
+++ b/tools/executors/directus/impl.js
@@ -1,95 +1,203 @@
-"use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+'use strict'
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value)
+          })
+    }
     return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
-var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
-    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
-        if (ar || !(i in from)) {
-            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
-            ar[i] = from[i];
+      function fulfilled(value) {
+        try {
+          step(generator.next(value))
+        } catch (e) {
+          reject(e)
         }
+      }
+      function rejected(value) {
+        try {
+          step(generator['throw'](value))
+        } catch (e) {
+          reject(e)
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected)
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next())
+    })
+  }
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1]
+          return t[1]
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === 'function' &&
+        (g[Symbol.iterator] = function () {
+          return this
+        }),
+      g
+    )
+    function verb(n) {
+      return function (v) {
+        return step([n, v])
+      }
     }
-    return to.concat(ar || Array.prototype.slice.call(from));
-};
-exports.__esModule = true;
-var node_child_process_1 = require("node:child_process");
-var node_path_1 = require("node:path");
+    function step(op) {
+      if (f) throw new TypeError('Generator is already executing.')
+      while (_)
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y['return']
+                  : op[0]
+                  ? y['throw'] || ((t = y['return']) && t.call(y), 0)
+                  : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t
+          if (((y = 0), t)) op = [op[0] & 2, t.value]
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op
+              break
+            case 4:
+              _.label++
+              return { value: op[1], done: false }
+            case 5:
+              _.label++
+              y = op[1]
+              op = [0]
+              continue
+            case 7:
+              op = _.ops.pop()
+              _.trys.pop()
+              continue
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0
+                continue
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1]
+                break
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1]
+                t = op
+                break
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2]
+                _.ops.push(op)
+                break
+              }
+              if (t[2]) _.ops.pop()
+              _.trys.pop()
+              continue
+          }
+          op = body.call(thisArg, _)
+        } catch (e) {
+          op = [6, e]
+          y = 0
+        } finally {
+          f = t = 0
+        }
+      if (op[0] & 5) throw op[1]
+      return { value: op[0] ? op[1] : void 0, done: true }
+    }
+  }
+var __spreadArray =
+  (this && this.__spreadArray) ||
+  function (to, from, pack) {
+    if (pack || arguments.length === 2)
+      for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+          if (!ar) ar = Array.prototype.slice.call(from, 0, i)
+          ar[i] = from[i]
+        }
+      }
+    return to.concat(ar || Array.prototype.slice.call(from))
+  }
+exports.__esModule = true
+var node_child_process_1 = require('node:child_process')
+var node_path_1 = require('node:path')
 function runAction(options, context) {
-    return __awaiter(this, void 0, void 0, function () {
-        return __generator(this, function (_a) {
-            return [2 /*return*/, new Promise(function (resolve, reject) {
-                    var directus = (0, node_child_process_1.spawn)('npx', __spreadArray(['directus', options.action], options.args, true), {
-                        cwd: (0, node_path_1.join)(context.cwd, context.workspace.projects[context.projectName].root),
-                        stdio: 'inherit'
-                    });
-                    process.on('SIGTERM', function () {
-                        directus.kill();
-                        process.exit(128 + 15);
-                    });
-                    process.on('exit', function (code) {
-                        process.exit(code);
-                    });
-                    directus.on('error', function (error) {
-                        reject(error);
-                    });
-                    directus.on('exit', function () {
-                        console.log('exit');
-                        reject();
-                    });
-                })];
-        });
-    });
+  return __awaiter(this, void 0, void 0, function () {
+    return __generator(this, function (_a) {
+      return [
+        2 /*return*/,
+        new Promise(function (resolve, reject) {
+          var directus = (0, node_child_process_1.spawn)(
+            'npx',
+            __spreadArray(['directus', options.action], options.args, true),
+            {
+              cwd: (0, node_path_1.join)(
+                context.cwd,
+                context.workspace.projects[context.projectName].root
+              ),
+              stdio: 'inherit',
+            }
+          )
+          process.on('SIGTERM', function () {
+            console.log('sigterm')
+            directus.kill()
+            process.exit(128 + 15)
+          })
+          process.on('exit', function (code) {
+            console.log('exit')
+            process.exit(code)
+          })
+          directus.on('error', function (error) {
+            reject(error)
+          })
+          directus.on('exit', function (code) {
+            if (code !== 0) {
+              reject(code)
+            }
+            resolve(true)
+          })
+        }),
+      ]
+    })
+  })
 }
 function directusExecutor(options, context) {
-    return __awaiter(this, void 0, void 0, function () {
-        var e_1;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    _a.trys.push([0, 2, , 3]);
-                    return [4 /*yield*/, runAction(options, context)];
-                case 1:
-                    _a.sent();
-                    return [2 /*return*/, { success: true }];
-                case 2:
-                    e_1 = _a.sent();
-                    throw e_1;
-                case 3: return [2 /*return*/];
-            }
-        });
-    });
+  return __awaiter(this, void 0, void 0, function () {
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          return [4 /*yield*/, runAction(options, context)]
+        case 1:
+          _a.sent()
+          return [2 /*return*/]
+      }
+    })
+  })
 }
-exports["default"] = directusExecutor;
+exports['default'] = directusExecutor

--- a/tools/executors/directus/impl.js
+++ b/tools/executors/directus/impl.js
@@ -1,198 +1,95 @@
-'use strict'
-var __awaiter =
-  (this && this.__awaiter) ||
-  function (thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P
-        ? value
-        : new P(function (resolve) {
-            resolve(value)
-          })
-    }
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value))
-        } catch (e) {
-          reject(e)
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator['throw'](value))
-        } catch (e) {
-          reject(e)
-        }
-      }
-      function step(result) {
-        result.done
-          ? resolve(result.value)
-          : adopt(result.value).then(fulfilled, rejected)
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next())
-    })
-  }
-var __generator =
-  (this && this.__generator) ||
-  function (thisArg, body) {
-    var _ = {
-        label: 0,
-        sent: function () {
-          if (t[0] & 1) throw t[1]
-          return t[1]
-        },
-        trys: [],
-        ops: [],
-      },
-      f,
-      y,
-      t,
-      g
-    return (
-      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
-      typeof Symbol === 'function' &&
-        (g[Symbol.iterator] = function () {
-          return this
-        }),
-      g
-    )
-    function verb(n) {
-      return function (v) {
-        return step([n, v])
-      }
-    }
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
-      if (f) throw new TypeError('Generator is already executing.')
-      while (_)
-        try {
-          if (
-            ((f = 1),
-            y &&
-              (t =
-                op[0] & 2
-                  ? y['return']
-                  : op[0]
-                  ? y['throw'] || ((t = y['return']) && t.call(y), 0)
-                  : y.next) &&
-              !(t = t.call(y, op[1])).done)
-          )
-            return t
-          if (((y = 0), t)) op = [op[0] & 2, t.value]
-          switch (op[0]) {
-            case 0:
-            case 1:
-              t = op
-              break
-            case 4:
-              _.label++
-              return { value: op[1], done: false }
-            case 5:
-              _.label++
-              y = op[1]
-              op = [0]
-              continue
-            case 7:
-              op = _.ops.pop()
-              _.trys.pop()
-              continue
-            default:
-              if (
-                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
-                (op[0] === 6 || op[0] === 2)
-              ) {
-                _ = 0
-                continue
-              }
-              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
-                _.label = op[1]
-                break
-              }
-              if (op[0] === 6 && _.label < t[1]) {
-                _.label = t[1]
-                t = op
-                break
-              }
-              if (t && _.label < t[2]) {
-                _.label = t[2]
-                _.ops.push(op)
-                break
-              }
-              if (t[2]) _.ops.pop()
-              _.trys.pop()
-              continue
-          }
-          op = body.call(thisArg, _)
-        } catch (e) {
-          op = [6, e]
-          y = 0
-        } finally {
-          f = t = 0
-        }
-      if (op[0] & 5) throw op[1]
-      return { value: op[0] ? op[1] : void 0, done: true }
-    }
-  }
-var __spreadArray =
-  (this && this.__spreadArray) ||
-  function (to, from, pack) {
-    if (pack || arguments.length === 2)
-      for (var i = 0, l = from.length, ar; i < l; i++) {
-        if (ar || !(i in from)) {
-          if (!ar) ar = Array.prototype.slice.call(from, 0, i)
-          ar[i] = from[i]
-        }
-      }
-    return to.concat(ar || Array.prototype.slice.call(from))
-  }
-exports.__esModule = true
-var node_child_process_1 = require('node:child_process')
-var node_path_1 = require('node:path')
-function runAction(options, context) {
-  return __awaiter(this, void 0, void 0, function () {
-    return __generator(this, function (_a) {
-      return [
-        2 /*return*/,
-        new Promise(function (resolve, reject) {
-          var directus = (0, node_child_process_1.spawn)(
-            'npx',
-            __spreadArray(['directus', options.action], options.args, true),
-            {
-              cwd: (0, node_path_1.join)(
-                context.cwd,
-                context.workspace.projects[context.projectName].root
-              ),
-              stdio: 'inherit',
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
             }
-          )
-          process.on('SIGTERM', function () {
-            directus.kill()
-            process.exit(128 + 15)
-          })
-          process.on('exit', function (code) {
-            process.exit(code)
-          })
-          directus.on('error', function (error) {
-            reject(error)
-          })
-          directus.on('exit', function () {
-            resolve(true)
-          })
-        }),
-      ]
-    })
-  })
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+exports.__esModule = true;
+var node_child_process_1 = require("node:child_process");
+var node_path_1 = require("node:path");
+function runAction(options, context) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            return [2 /*return*/, new Promise(function (resolve, reject) {
+                    var directus = (0, node_child_process_1.spawn)('npx', __spreadArray(['directus', options.action], options.args, true), {
+                        cwd: (0, node_path_1.join)(context.cwd, context.workspace.projects[context.projectName].root),
+                        stdio: 'inherit'
+                    });
+                    process.on('SIGTERM', function () {
+                        directus.kill();
+                        process.exit(128 + 15);
+                    });
+                    process.on('exit', function (code) {
+                        process.exit(code);
+                    });
+                    directus.on('error', function (error) {
+                        reject(error);
+                    });
+                    directus.on('exit', function () {
+                        console.log('exit');
+                        reject();
+                    });
+                })];
+        });
+    });
 }
 function directusExecutor(options, context) {
-  return __awaiter(this, void 0, void 0, function () {
-    return __generator(this, function (_a) {
-      switch (_a.label) {
-        case 0:
-          return [4 /*yield*/, runAction(options, context)]
-        case 1:
-          _a.sent()
-          return [2 /*return*/, { success: true }]
-      }
-    })
-  })
+    return __awaiter(this, void 0, void 0, function () {
+        var e_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    _a.trys.push([0, 2, , 3]);
+                    return [4 /*yield*/, runAction(options, context)];
+                case 1:
+                    _a.sent();
+                    return [2 /*return*/, { success: true }];
+                case 2:
+                    e_1 = _a.sent();
+                    throw e_1;
+                case 3: return [2 /*return*/];
+            }
+        });
+    });
 }
-exports['default'] = directusExecutor
+exports["default"] = directusExecutor;

--- a/tools/executors/directus/impl.js
+++ b/tools/executors/directus/impl.js
@@ -165,12 +165,10 @@ function runAction(options, context) {
             }
           )
           process.on('SIGTERM', function () {
-            console.log('sigterm')
             directus.kill()
             process.exit(128 + 15)
           })
           process.on('exit', function (code) {
-            console.log('exit')
             process.exit(code)
           })
           directus.on('error', function (error) {

--- a/tools/executors/directus/impl.ts
+++ b/tools/executors/directus/impl.ts
@@ -60,4 +60,5 @@ export default async function directusExecutor(
   context: ExecutorContext
 ) {
   await runAction(options, context)
+  return { success: true }
 }

--- a/tools/executors/directus/impl.ts
+++ b/tools/executors/directus/impl.ts
@@ -33,11 +33,13 @@ async function runAction(
     )
 
     process.on('SIGTERM', () => {
+      console.log('sigterm')
       directus.kill()
       process.exit(128 + 15)
     })
 
     process.on('exit', (code) => {
+      console.log('exit')
       process.exit(code)
     })
 
@@ -45,7 +47,11 @@ async function runAction(
       reject(error)
     })
 
-    directus.on('exit', () => {
+    directus.on('exit', (code) => {
+      if (code !== 0) {
+        reject(code)
+      }
+
       resolve(true)
     })
   })
@@ -55,11 +61,5 @@ export default async function directusExecutor(
   options: DirectusExecutorOptions,
   context: ExecutorContext
 ) {
-  try {
-    await runAction(options, context);
-
-    return { success: true };
-  } catch (e) {
-    throw e;
-  }
+  await runAction(options, context)
 }

--- a/tools/executors/directus/impl.ts
+++ b/tools/executors/directus/impl.ts
@@ -55,6 +55,11 @@ export default async function directusExecutor(
   options: DirectusExecutorOptions,
   context: ExecutorContext
 ) {
-  await runAction(options, context)
-  return { success: true }
+  try {
+    await runAction(options, context);
+
+    return { success: true };
+  } catch (e) {
+    throw e;
+  }
 }

--- a/tools/executors/directus/impl.ts
+++ b/tools/executors/directus/impl.ts
@@ -48,6 +48,7 @@ async function runAction(
     directus.on('exit', (code) => {
       if (code !== 0) {
         reject(code)
+        return
       }
 
       resolve(true)

--- a/tools/executors/directus/impl.ts
+++ b/tools/executors/directus/impl.ts
@@ -33,13 +33,11 @@ async function runAction(
     )
 
     process.on('SIGTERM', () => {
-      console.log('sigterm')
       directus.kill()
       process.exit(128 + 15)
     })
 
     process.on('exit', (code) => {
-      console.log('exit')
       process.exit(code)
     })
 


### PR DESCRIPTION
Fix of various typos and missing clarity of READMEs.

Added an additional step to CMS setup regarding creating a DB schema that matches the `DB_SEARCH_PATH` environment variable. The env example has `cms` as a value there, so if you keep that value without creating a schema, `nx bootstrap cms` will fail.

BUT it will tell you it succeeded - so I additionally modified the executor to throw an error if there's an error instead of always returning success.

May also modify bottom portion of the CMS Readme before merge, see: https://rocketinsights.slack.com/archives/C01RTKC55R6/p1643668237913089
