### PR TITLE
[#269] Revoke pack endpoint

### DIFF
--- a/apps/api/src/lib/algorand-adapter.ts
+++ b/apps/api/src/lib/algorand-adapter.ts
@@ -473,7 +473,7 @@ export default class AlgorandAdapter {
       to: options.toAccountAddress,
     })
 
-    // Receiver needs to "opt-in" to the asset by using a "zero-balance" transaction
+    // Creator needs to "opt-in" to the asset by using a "zero-balance" transaction
     const optInTxn = algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({
       suggestedParams,
       amount: 0,
@@ -496,9 +496,16 @@ export default class AlgorandAdapter {
     // Adds a group id to each transaction object
     algosdk.assignGroupID([fundsTxn, optInTxn, clawbackTxn])
 
+    // Find secret key for creator account
+    const creator = await this.getCreatorAccount(0)
+    const toAccount = algosdk.mnemonicToSecretKey(
+      decrypt(creator.encryptedMnemonic, Configuration.creatorPassphrase)
+    )
+    console.log('toAccount:', toAccount)
+
     const signedTransactions = [
       fundsTxn.signTxn(this.fundingAccount.sk),
-      optInTxn.signTxn(this.fundingAccount.sk),
+      optInTxn.signTxn(toAccount.sk),
       clawbackTxn.signTxn(this.fundingAccount.sk),
     ]
 

--- a/apps/api/src/modules/collectibles/collectibles.service.ts
+++ b/apps/api/src/modules/collectibles/collectibles.service.ts
@@ -627,7 +627,7 @@ export default class CollectiblesService {
       }))
     )
 
-    // Remover ownership from collectible
+    // Remove ownership from collectible
     await CollectibleModel.query(trx).where('id', collectible.id).patch({
       ownerId: null,
       latestTransferTransactionId: transactions[0].id,

--- a/apps/api/src/modules/packs/index.ts
+++ b/apps/api/src/modules/packs/index.ts
@@ -17,6 +17,7 @@ import {
   PublishedPacksQuerySchema,
   PublishedPacksSchema,
   RedeemCodeSchema,
+  RevokePackSchema,
   TransferPackSchema,
   TransferPackStatusListSchema,
 } from '@algomart/schemas'
@@ -34,6 +35,7 @@ import {
   getPublishedPacks,
   getRedeemablePack,
   mintPackStatus,
+  revokePack,
   transferPack,
   transferPackStatus,
   untransferredPacks,
@@ -206,6 +208,23 @@ export async function packsRoutes(app: FastifyInstance) {
       },
     },
     mintPackStatus
+  )
+
+  app.post(
+    '/revoke',
+    {
+      schema: {
+        tags,
+        security,
+        body: RevokePackSchema,
+        description:
+          'Used to revoke a pack and collectibles from a user back to the creator.',
+        response: {
+          204: Type.Null(),
+        },
+      },
+    },
+    revokePack
   )
 
   app.post(

--- a/apps/api/src/modules/packs/packs.routes.ts
+++ b/apps/api/src/modules/packs/packs.routes.ts
@@ -11,6 +11,7 @@ import {
   PackTemplateId,
   PublishedPacksQuery,
   RedeemCode,
+  RevokePack,
   TransferPack,
 } from '@algomart/schemas'
 import { FastifyReply, FastifyRequest } from 'fastify'
@@ -144,6 +145,19 @@ export async function mintPackStatus(
   reply.send({
     status,
   })
+}
+
+export async function revokePack(
+  request: FastifyRequest<{ Body: RevokePack }>,
+  reply: FastifyReply
+) {
+  const service = request.getContainer().get<PacksService>(PacksService.name)
+  const result = await service.revokePack(request.body, request.transaction)
+  if (!result) {
+    reply.badRequest('Unable to revoke pack')
+    return
+  }
+  reply.status(204).send()
 }
 
 export async function transferPack(

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -868,17 +868,12 @@ export default class PacksService {
       userId = user.id
     }
 
-    const pack = PackModel.query(trx).where('id', request.packId)
-
-    if (userId) {
-      pack.where('ownerId', userId)
-    }
-
-    await pack
+    const pack = PackModel.query(trx)
+      .where('id', '=', request.packId)
       .select('id')
       .withGraphFetched('collectibles')
       .modifyGraph('collectibles', (builder) => {
-        builder.select('id')
+        builder.select('id', 'ownerId')
       })
       .first()
 
@@ -892,7 +887,7 @@ export default class PacksService {
 
     // Transfer
     await Promise.all(
-      pack?.collectibles?.map(
+      pack.collectibles?.map(
         async (c) =>
           c.ownerId &&
           c.id &&

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -868,35 +868,31 @@ export default class PacksService {
       userId = user.id
     }
 
-    const pack = PackModel.query(trx).where('id', request.packId)
+    const packQuery = PackModel.query(trx).where('id', request.packId)
 
     if (userId) {
-      pack.where('ownerId', userId)
+      packQuery.where('ownerId', request.ownerId)
     }
 
     if (request.fromAddress) {
-      pack.where('address', request.fromAddress)
+      packQuery.where('address', request.fromAddress)
     }
 
-    const pack = await pack
+    const pack = await packQuery
       .select('id')
       .withGraphFetched('collectibles')
       .modifyGraph('collectibles', (builder) => {
-        builder.select('id').select('ownerId')
+        builder.select('id')
       })
       .first()
 
     userInvariant(pack, 'pack not found', 404)
 
-    if (!pack) {
-      return false
-    }
-
     this.logger.info({ pack }, 'pack to be transferred')
 
     // Transfer
     await Promise.all(
-      pack.collectibles?.map(
+      pack?.collectibles?.map(
         async (c) =>
           c.ownerId &&
           c.id &&

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -896,7 +896,6 @@ export default class PacksService {
     const packWithBase = await this.getPackById(request.packId)
     if (packWithBase) {
       // @TODO: create notification for revoking the pack
-      console.log('pack with base:', packWithBase)
     }
 
     // Remove claim from pack

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -856,10 +856,7 @@ export default class PacksService {
   }
 
   async revokePack(request: RevokePack, trx?: Transaction) {
-    const user = await UserAccountModel.query(trx)
-      .findOne('externalId', request.ownerId)
-      .withGraphJoined('algorandAccount.creationTransaction')
-
+    const user = await UserAccountModel.query(trx).findById(request.ownerId)
     userInvariant(user, 'user not found', 404)
 
     const pack = await PackModel.query(trx)
@@ -899,6 +896,7 @@ export default class PacksService {
     const packWithBase = await this.getPackById(request.packId)
     if (packWithBase) {
       // @TODO: create notification for revoking the pack
+      console.log('pack with base:', packWithBase)
     }
 
     // Remove claim from pack

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -874,10 +874,6 @@ export default class PacksService {
       packQuery.where('ownerId', request.ownerId)
     }
 
-    if (request.fromAddress) {
-      packQuery.where('address', request.fromAddress)
-    }
-
     const pack = await packQuery
       .select('id')
       .withGraphFetched('collectibles')

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -856,12 +856,25 @@ export default class PacksService {
   }
 
   async revokePack(request: RevokePack, trx?: Transaction) {
-    const user = await UserAccountModel.query(trx).findById(request.ownerId)
-    userInvariant(user, 'user not found', 404)
+    invariant(
+      request.fromAddress || request.ownerId,
+      'Pack owner ID or address is required.'
+    )
+    let userId
 
-    const pack = await PackModel.query(trx)
-      .where('id', request.packId)
-      .where('ownerId', user.id)
+    if (request.ownerId) {
+      const user = await UserAccountModel.query(trx).findById(request.ownerId)
+      userInvariant(user, 'user not found', 404)
+      userId = user.id
+    }
+
+    const pack = PackModel.query(trx).where('id', request.packId)
+
+    if (userId) {
+      pack.where('ownerId', userId)
+    }
+
+    await pack
       .select('id')
       .withGraphFetched('collectibles')
       .modifyGraph('collectibles', (builder) => {
@@ -879,14 +892,14 @@ export default class PacksService {
 
     // Transfer
     await Promise.all(
-      pack.collectibles?.map(
+      pack?.collectibles?.map(
         async (c) =>
           c.ownerId &&
           c.id &&
           (await this.collectibles.transferToCreatorFromUser(
             c.id,
-            null,
-            user.id,
+            request.fromAddress,
+            userId,
             trx
           ))
       )

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -687,7 +687,7 @@ export default class PacksService {
     await Promise.all(
       pack.collectibles?.map(
         async (c) =>
-          !c.ownerId &&
+          c.ownerId &&
           c.id &&
           (await this.collectibles.transferToUserFromCreator(
             c.id,

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -880,17 +880,18 @@ export default class PacksService {
 
     this.logger.info({ pack }, 'pack to be transferred')
 
-    if (user.algorandAccount?.creationTransactionId === null) {
-      // @TODO: How do we handle?
-      // await this.accounts.initializeAccount(user.id, request.passphrase, trx)
-    }
-
     const collectibleIds = pack.collectibles?.map((c) => c.id) || []
 
     // Transfer
     await Promise.all(
       collectibleIds.map(async (id) => {
-        await this.collectibles.transferToCreatorFromUser(id, user.id, trx)
+        // @TODO: Optionally accept an account address
+        await this.collectibles.transferToCreatorFromUser(
+          id,
+          null,
+          user.id,
+          trx
+        )
       })
     )
 

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -881,7 +881,6 @@ export default class PacksService {
         builder.select('id')
       })
       .first()
-    console.log('pack', pack)
 
     userInvariant(pack, 'pack not found', 404)
 

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -868,12 +868,21 @@ export default class PacksService {
       userId = user.id
     }
 
-    const pack = PackModel.query(trx)
-      .where('id', '=', request.packId)
+    const pack = PackModel.query(trx).where('id', request.packId)
+
+    if (userId) {
+      pack.where('ownerId', userId)
+    }
+
+    if (request.fromAddress) {
+      pack.where('address', request.fromAddress)
+    }
+
+    const pack = await pack
       .select('id')
       .withGraphFetched('collectibles')
       .modifyGraph('collectibles', (builder) => {
-        builder.select('id', 'ownerId')
+        builder.select('id').select('ownerId')
       })
       .first()
 

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -684,17 +684,18 @@ export default class PacksService {
       await this.accounts.initializeAccount(user.id, request.passphrase, trx)
     }
 
-    const collectibleIds = pack.collectibles?.map((c) => c.id) || []
-
     await Promise.all(
-      collectibleIds.map(async (id) => {
-        await this.collectibles.transferToUserFromCreator(
-          id,
-          user.id,
-          request.passphrase,
-          trx
-        )
-      })
+      pack.collectibles?.map(
+        async (c) =>
+          !c.ownerId &&
+          c.id &&
+          (await this.collectibles.transferToUserFromCreator(
+            c.id,
+            user.id,
+            request.passphrase,
+            trx
+          ))
+      )
     )
 
     // Create transfer success notification to be sent to user

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -684,18 +684,17 @@ export default class PacksService {
       await this.accounts.initializeAccount(user.id, request.passphrase, trx)
     }
 
+    const collectibleIds = pack.collectibles?.map((c) => c.id) || []
+
     await Promise.all(
-      pack.collectibles?.map(
-        async (c) =>
-          c.ownerId &&
-          c.id &&
-          (await this.collectibles.transferToUserFromCreator(
-            c.id,
-            user.id,
-            request.passphrase,
-            trx
-          ))
-      )
+      collectibleIds.map(async (id) => {
+        await this.collectibles.transferToUserFromCreator(
+          id,
+          user.id,
+          request.passphrase,
+          trx
+        )
+      })
     )
 
     // Create transfer success notification to be sent to user
@@ -878,19 +877,19 @@ export default class PacksService {
 
     this.logger.info({ pack }, 'pack to be transferred')
 
-    const collectibleIds = pack.collectibles?.map((c) => c.id) || []
-
     // Transfer
     await Promise.all(
-      collectibleIds.map(async (id) => {
-        // @TODO: Optionally accept an account address
-        await this.collectibles.transferToCreatorFromUser(
-          id,
-          null,
-          user.id,
-          trx
-        )
-      })
+      pack.collectibles?.map(
+        async (c) =>
+          c.ownerId &&
+          c.id &&
+          (await this.collectibles.transferToCreatorFromUser(
+            c.id,
+            null,
+            user.id,
+            trx
+          ))
+      )
     )
 
     // Create transfer success notification to be sent to user

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -881,6 +881,7 @@ export default class PacksService {
         builder.select('id')
       })
       .first()
+    console.log('pack', pack)
 
     userInvariant(pack, 'pack not found', 404)
 

--- a/apps/api/src/modules/payments/index.ts
+++ b/apps/api/src/modules/payments/index.ts
@@ -1,7 +1,4 @@
 import {
-  AdminPaymentBaseSchema,
-  AdminPaymentListQuerystringSchema,
-  AdminPaymentListSchema,
   BankAccountIdSchema,
   CardIdSchema,
   CircleBlockchainAddressSchema,
@@ -20,7 +17,10 @@ import {
   PaymentBankAccountInstructionsSchema,
   PaymentCardsSchema,
   PaymentIdSchema,
+  PaymentQuerystringSchema,
   PaymentSchema,
+  PaymentsQuerystringSchema,
+  PaymentsSchema,
   PublicKeySchema,
   SendBankAccountInstructionsSchema,
   ToPaymentBaseSchema,
@@ -39,7 +39,6 @@ import {
   createWalletAddress,
   findTransferByAddress,
   findWirePaymentsByBankId,
-  getAdminPaymentById,
   getBankAccountStatus,
   getCards,
   getCardStatus,
@@ -80,9 +79,9 @@ export async function paymentRoutes(app: FastifyInstance) {
         schema: {
           tags,
           security,
-          querystring: AdminPaymentListQuerystringSchema,
+          querystring: PaymentsQuerystringSchema,
           response: {
-            200: AdminPaymentListSchema,
+            200: PaymentsSchema,
           },
         },
       },
@@ -95,26 +94,13 @@ export async function paymentRoutes(app: FastifyInstance) {
           tags,
           security,
           params: PaymentIdSchema,
+          querystring: PaymentQuerystringSchema,
           response: {
             200: PaymentSchema,
           },
         },
       },
       getPaymentById
-    )
-    .get(
-      '/:paymentId/admin',
-      {
-        schema: {
-          tags,
-          security,
-          params: PaymentIdSchema,
-          response: {
-            200: AdminPaymentBaseSchema,
-          },
-        },
-      },
-      getAdminPaymentById
     )
     .get(
       '/encryption-public-key',

--- a/apps/api/src/modules/payments/payments.routes.ts
+++ b/apps/api/src/modules/payments/payments.routes.ts
@@ -1,5 +1,4 @@
 import {
-  AdminPaymentListQuerystring,
   BankAccountId,
   CardId,
   CreateBankAccount,
@@ -10,6 +9,8 @@ import {
   FindTransferByAddress,
   OwnerExternalId,
   PaymentId,
+  PaymentQuerystring,
+  PaymentsQuerystring,
   SendBankAccountInstructions,
   UpdatePayment,
   UpdatePaymentCard,
@@ -278,35 +279,20 @@ export async function createTransferPayment(
   }
 }
 
-export async function getAdminPaymentById(
-  request: FastifyRequest<{
-    Params: PaymentId
-  }>,
-  reply: FastifyReply
-) {
-  const paymentService = request
-    .getContainer()
-    .get<PaymentsService>(PaymentsService.name)
-  const payment = await paymentService.getAdminPaymentById(
-    request.params.paymentId
-  )
-  if (payment) {
-    reply.status(200).send(payment)
-  } else {
-    reply.notFound()
-  }
-}
-
 export async function getPaymentById(
   request: FastifyRequest<{
     Params: PaymentId
+    Querystring: PaymentQuerystring
   }>,
   reply: FastifyReply
 ) {
   const paymentService = request
     .getContainer()
     .get<PaymentsService>(PaymentsService.name)
-  const payment = await paymentService.getPaymentById(request.params.paymentId)
+  const payment = await paymentService.getPaymentById(
+    request.params.paymentId,
+    request.query.isAdmin
+  )
   if (payment) {
     reply.status(200).send(payment)
   } else {
@@ -316,7 +302,7 @@ export async function getPaymentById(
 
 export async function getPayments(
   request: FastifyRequest<{
-    Querystring: AdminPaymentListQuerystring
+    Querystring: PaymentsQuerystring
   }>,
   reply: FastifyReply
 ) {

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -740,7 +740,9 @@ export default class PaymentsService {
     return sourcePayment
   }
 
-  async searchAllWirePaymentsByBankId(bankAccountId: string) {
+  async searchAllWirePaymentsByBankId(
+    bankAccountId: string
+  ): Promise<ToPaymentBase[]> {
     userInvariant(
       bankAccountId,
       'bank account identifier was not provided',
@@ -759,13 +761,14 @@ export default class PaymentsService {
       type: CirclePaymentQueryType.wire,
       source: foundBankAccount.externalId,
     })
-    return matchingPayments
+    return matchingPayments || []
   }
 
   async getPaymentById(paymentId: string, isAdmin?: boolean) {
     const payment = await PaymentModel.query()
       .findById(paymentId)
       .withGraphFetched('pack')
+      .withGraphFetched('payer')
     userInvariant(payment, 'payment not found', 404)
     if (isAdmin) {
       const { pack } = payment

--- a/apps/web/src/clients/api-client.ts
+++ b/apps/web/src/clients/api-client.ts
@@ -48,6 +48,7 @@ import {
   PublishedPacks,
   PublishedPacksQuery,
   RedeemCode,
+  RevokePack,
   SendBankAccountInstructions,
   SetWithCollection,
   SingleCollectibleQuerystring,
@@ -392,6 +393,12 @@ export class ApiClient {
     return await this.http
       .get('packs/mint', { searchParams: params })
       .json<MintPackStatusResponse>()
+  }
+
+  async revokePack(json: RevokePack) {
+    return await this.http
+      .post('packs/revoke', { json })
+      .then((response) => response.ok)
   }
 
   async transferPack(json: TransferPack) {

--- a/apps/web/src/clients/api-client.ts
+++ b/apps/web/src/clients/api-client.ts
@@ -1,7 +1,4 @@
 import {
-  AdminPaymentBase,
-  AdminPaymentList,
-  AdminPaymentListQuerystring,
   CircleBlockchainAddress,
   ClaimFreePack,
   ClaimPack,
@@ -44,6 +41,8 @@ import {
   PaymentBankAccountInstructions,
   PaymentCard,
   PaymentCards,
+  Payments,
+  PaymentsQuerystring,
   PublicAccount,
   PublicKey,
   PublishedPacks,
@@ -316,17 +315,15 @@ export class ApiClient {
       .catch(() => null)
   }
 
-  async getPayments(query: AdminPaymentListQuerystring) {
+  async getPayments(query: PaymentsQuerystring) {
     const searchQuery = getPaymentsFilterQuery(query)
-    return await this.http
-      .get(`payments?${searchQuery}`)
-      .json<AdminPaymentList>()
+    return await this.http.get(`payments?${searchQuery}`).json<Payments>()
   }
 
   async getAdminPaymentById(paymentId: string) {
     return await this.http
-      .get(`payments/${paymentId}/admin`)
-      .json<AdminPaymentBase>()
+      .get(`payments/${paymentId}?admin=true`)
+      .json<Payment>()
   }
 
   async getPaymentsByBankAccountId(bankAccountId: string) {

--- a/apps/web/src/clients/api-client.ts
+++ b/apps/web/src/clients/api-client.ts
@@ -330,7 +330,7 @@ export class ApiClient {
   async getPaymentsByBankAccountId(bankAccountId: string) {
     return await this.http
       .get(`payments/bank-accounts/${bankAccountId}/payments`)
-      .json<Payment[]>()
+      .json<ToPaymentBase[]>()
   }
 
   async updatePaymentById(paymentId: string, json: UpdatePayment) {

--- a/apps/web/src/clients/api-client.ts
+++ b/apps/web/src/clients/api-client.ts
@@ -323,13 +323,13 @@ export class ApiClient {
 
   async getAdminPaymentById(paymentId: string) {
     return await this.http
-      .get(`payments/${paymentId}?admin=true`)
+      .get(`payments/${paymentId}?isAdmin=${true}`)
       .json<Payment>()
   }
 
   async getPaymentsByBankAccountId(bankAccountId: string) {
     return await this.http
-      .get(`bank-accounts/${bankAccountId}/payments`)
+      .get(`payments/bank-accounts/${bankAccountId}/payments`)
       .json<Payment[]>()
   }
 

--- a/apps/web/src/pages/admin/transactions/[transactionId].tsx
+++ b/apps/web/src/pages/admin/transactions/[transactionId].tsx
@@ -9,6 +9,7 @@ import Button from '@/components/button'
 import DefaultLayout from '@/layouts/default-layout'
 import adminService from '@/services/admin-service'
 import { isAuthenticatedUserAdmin } from '@/services/api/auth-service'
+import { logger } from '@/utils/logger'
 import { useAuthApi } from '@/utils/swr'
 import { urls } from '@/utils/urls'
 
@@ -47,8 +48,15 @@ export default function AdminTransactionPage({
   }, [transactionId])
 
   const handleRevokePack = useCallback(async () => {
-    // @TODO: Revoke pack API request
-  }, [])
+    try {
+      console.log('payment:', payment.pack)
+      if (!payment.pack.id) throw new Error('No pack id')
+      if (!payment.pack.ownerId) throw new Error('No pack owner ID')
+      await adminService.revokePack(payment.pack.id, payment.pack.ownerId)
+    } catch (error) {
+      logger.error(error, 'Unable to revoke pack')
+    }
+  }, [payment?.pack])
 
   return (
     <DefaultLayout pageTitle={t('common:pageTitles.Transaction')}>

--- a/apps/web/src/pages/admin/transactions/[transactionId].tsx
+++ b/apps/web/src/pages/admin/transactions/[transactionId].tsx
@@ -32,19 +32,27 @@ export default function AdminTransactionPage({
 
   const handleReset = useCallback(async () => {
     const paymentId = typeof transactionId === 'string' ? transactionId : null
-    const updatedPayment = await adminService.updatePayment(paymentId, {
-      externalId: '',
-      status: PaymentStatus.Pending,
-    })
-    console.log('reset payment:', updatedPayment)
+    try {
+      const updatedPayment = await adminService.updatePayment(paymentId, {
+        externalId: '',
+        status: PaymentStatus.Pending,
+      })
+      console.log('reset payment:', updatedPayment)
+    } catch (error) {
+      logger.error(error, 'Unable to reset pack')
+    }
   }, [transactionId])
 
   const markAsPaid = useCallback(async () => {
     const paymentId = typeof transactionId === 'string' ? transactionId : null
-    const updatedPayment = await adminService.updatePayment(paymentId, {
-      status: PaymentStatus.Paid,
-    })
-    console.log('marked payment as paid:', updatedPayment)
+    try {
+      const updatedPayment = await adminService.updatePayment(paymentId, {
+        status: PaymentStatus.Paid,
+      })
+      console.log('marked payment as paid:', updatedPayment)
+    } catch (error) {
+      logger.error(error, 'Unable to update pack as paid')
+    }
   }, [transactionId])
 
   const handleRevokePack = useCallback(async () => {

--- a/apps/web/src/pages/admin/transactions/[transactionId].tsx
+++ b/apps/web/src/pages/admin/transactions/[transactionId].tsx
@@ -37,7 +37,7 @@ export default function AdminTransactionPage({
         externalId: '',
         status: PaymentStatus.Pending,
       })
-      console.log('reset payment:', updatedPayment)
+      logger.info(updatedPayment, 'Payment was reset')
     } catch (error) {
       logger.error(error, 'Unable to reset pack')
     }
@@ -49,7 +49,7 @@ export default function AdminTransactionPage({
       const updatedPayment = await adminService.updatePayment(paymentId, {
         status: PaymentStatus.Paid,
       })
-      console.log('marked payment as paid:', updatedPayment)
+      logger.info(updatedPayment, 'Payment marked as paid')
     } catch (error) {
       logger.error(error, 'Unable to update pack as paid')
     }
@@ -57,10 +57,11 @@ export default function AdminTransactionPage({
 
   const handleRevokePack = useCallback(async () => {
     try {
-      console.log('payment:', payment.pack)
       if (!payment.pack.id) throw new Error('No pack id')
       if (!payment.pack.ownerId) throw new Error('No pack owner ID')
+      // Revoke pack
       await adminService.revokePack(payment.pack.id, payment.pack.ownerId)
+      logger.info('Pack was revoked')
     } catch (error) {
       logger.error(error, 'Unable to revoke pack')
     }

--- a/apps/web/src/pages/admin/transactions/[transactionId].tsx
+++ b/apps/web/src/pages/admin/transactions/[transactionId].tsx
@@ -70,13 +70,28 @@ export default function AdminTransactionPage({
   return (
     <DefaultLayout pageTitle={t('common:pageTitles.Transaction')}>
       {/**** @TODO: Transaction template *****/}
-      <Button className="mb-5" onClick={handleReset} fullWidth>
+      <Button
+        className="mb-5"
+        disabled={payment?.status === PaymentStatus.Pending}
+        fullWidth
+        onClick={handleReset}
+      >
         {t('common:actions.Reset Payment')}
       </Button>
-      <Button className="mb-5" onClick={markAsPaid} fullWidth>
+      <Button
+        className="mb-5"
+        disabled={payment?.status === PaymentStatus.Paid}
+        fullWidth
+        onClick={markAsPaid}
+      >
         {t('common:actions.Set Payment As Successful')}
       </Button>
-      <Button className="mb-5" onClick={handleRevokePack} fullWidth>
+      <Button
+        className="mb-5"
+        disabled={!payment?.pack?.ownerId}
+        fullWidth
+        onClick={handleRevokePack}
+      >
         {t('common:actions.Revoke Pack')}
       </Button>
     </DefaultLayout>

--- a/apps/web/src/pages/admin/transactions/[transactionId].tsx
+++ b/apps/web/src/pages/admin/transactions/[transactionId].tsx
@@ -20,15 +20,15 @@ interface AdminTransactionPageProps {
 export default function AdminTransactionPage({
   payment,
 }: AdminTransactionPageProps) {
+  logger.info(payment, 'Payment found')
   const { t } = useTranslation('admin')
   const { query } = useRouter()
   const { transactionId } = query
-  console.log('payment:', payment)
 
   const { data } = useAuthApi<Payment[]>(
     `${urls.api.v1.admin.getPaymentsForBankAccount}?bankAccountId=${payment.paymentBankId}`
   )
-  console.log('all payments for bank account:', data)
+  logger.info(data, 'Payments for bank account were retrieved')
 
   const handleReset = useCallback(async () => {
     const paymentId = typeof transactionId === 'string' ? transactionId : null

--- a/apps/web/src/pages/admin/transactions/[transactionId].tsx
+++ b/apps/web/src/pages/admin/transactions/[transactionId].tsx
@@ -1,4 +1,4 @@
-import { Payment, PaymentStatus } from '@algomart/schemas'
+import { Payment, PaymentStatus, ToPaymentBase } from '@algomart/schemas'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import useTranslation from 'next-translate/useTranslation'
@@ -25,7 +25,7 @@ export default function AdminTransactionPage({
   const { query } = useRouter()
   const { transactionId } = query
 
-  const { data } = useAuthApi<Payment[]>(
+  const { data } = useAuthApi<ToPaymentBase[]>(
     `${urls.api.v1.admin.getPaymentsForBankAccount}?bankAccountId=${payment.paymentBankId}`
   )
   logger.info(data, 'Payments for bank account were retrieved')

--- a/apps/web/src/pages/admin/transactions/index.tsx
+++ b/apps/web/src/pages/admin/transactions/index.tsx
@@ -1,7 +1,7 @@
 import {
-  AdminPaymentBase,
-  AdminPaymentList,
   FirebaseClaim,
+  Payment,
+  Payments,
   PaymentSortField,
 } from '@algomart/schemas'
 import { RefreshIcon } from '@heroicons/react/outline'
@@ -60,11 +60,11 @@ export default function AdminTransactionsPage() {
     sortDirection,
     pageSize: PAYMENTS_PER_PAGE,
   })
-  const { data, isValidating } = useAuthApi<AdminPaymentList>(
+  const { data, isValidating } = useAuthApi<Payments>(
     `${urls.api.v1.admin.getPayments}?${qp}`
   )
 
-  const columns: ColumnDefinitionType<AdminPaymentBase>[] = [
+  const columns: ColumnDefinitionType<Payment>[] = [
     { key: 'pack.title', name: t('transactions.table.title') },
     {
       key: 'createdAt',
@@ -111,7 +111,7 @@ export default function AdminTransactionsPage() {
         footer={footer}
       >
         <div className="overflow-x-auto">
-          <Table<AdminPaymentBase>
+          <Table<Payment>
             columns={columns}
             data={data?.payments}
             onHeaderClick={handleTableHeaderClick}

--- a/apps/web/src/pages/api/v1/asset/revoke.ts
+++ b/apps/web/src/pages/api/v1/asset/revoke.ts
@@ -1,0 +1,34 @@
+import { NextApiResponse } from 'next'
+
+import { ApiClient } from '@/clients/api-client'
+import createHandler, { NextApiRequestApp } from '@/middleware'
+import adminMiddleware from '@/middleware/admin-middleware'
+import authMiddleware from '@/middleware/auth-middleware'
+import userMiddleware from '@/middleware/user-middleware'
+import validateBodyMiddleware, {
+  ExtractBodyType,
+} from '@/middleware/validate-body-middleware'
+import { validateRevokeAsset } from '@/utils/asset-validation'
+
+const handler = createHandler()
+
+handler.use(authMiddleware()).use(userMiddleware()).use(adminMiddleware())
+
+type BodyType = ExtractBodyType<typeof validateRevokeAsset>
+
+handler.post(
+  validateBodyMiddleware(validateRevokeAsset),
+  async (request: NextApiRequestApp<BodyType>, response: NextApiResponse) => {
+    const { externalId } = request.user
+    const { packId } = request.validResult.value as BodyType
+
+    const result = await ApiClient.instance.revokePack({
+      packId,
+      ownerId: externalId,
+    })
+
+    response.json(result)
+  }
+)
+
+export default handler

--- a/apps/web/src/pages/api/v1/asset/revoke.ts
+++ b/apps/web/src/pages/api/v1/asset/revoke.ts
@@ -19,12 +19,11 @@ type BodyType = ExtractBodyType<typeof validateRevokeAsset>
 handler.post(
   validateBodyMiddleware(validateRevokeAsset),
   async (request: NextApiRequestApp<BodyType>, response: NextApiResponse) => {
-    const { externalId } = request.user
-    const { packId } = request.validResult.value as BodyType
+    const { packId, ownerId } = request.validResult.value as BodyType
 
     const result = await ApiClient.instance.revokePack({
       packId,
-      ownerId: externalId,
+      ownerId,
     })
 
     response.json(result)

--- a/apps/web/src/services/admin-service.ts
+++ b/apps/web/src/services/admin-service.ts
@@ -1,4 +1,9 @@
-import { AdminPermissions, Payment, UpdatePayment } from '@algomart/schemas'
+import {
+  AdminPermissions,
+  Payment,
+  Payments,
+  UpdatePayment,
+} from '@algomart/schemas'
 import { getAuth } from 'firebase/auth'
 import ky from 'ky'
 
@@ -7,6 +12,7 @@ import { urls } from '@/utils/urls'
 
 export interface AdminAPI {
   getLoggedInUserPermissions(): Promise<AdminPermissions>
+  getPaymentsByBankAccountId(bankAccountId: string): Promise<Payments>
   updatePayment(paymentId: string, json: UpdatePayment): Promise<Payment | null>
 }
 
@@ -41,6 +47,14 @@ export class AdminService implements AdminAPI {
       .get(urls.api.v1.adminGetClaims)
       .json<AdminPermissions>()
     return response
+  }
+
+  async getPaymentsByBankAccountId(bankAccountId: string): Promise<Payments> {
+    return await this.http
+      .get(
+        `${urls.api.v1.admin.getPaymentsForBankAccount}?bankAccountId=${bankAccountId}`
+      )
+      .json<Payments>()
   }
 
   async updatePayment(

--- a/apps/web/src/services/admin-service.ts
+++ b/apps/web/src/services/admin-service.ts
@@ -13,7 +13,7 @@ import { urls } from '@/utils/urls'
 export interface AdminAPI {
   getLoggedInUserPermissions(): Promise<AdminPermissions>
   getPaymentsByBankAccountId(bankAccountId: string): Promise<Payments>
-  revokePack: (packId: string) => Promise<boolean>
+  revokePack: (packId: string, ownerId: string) => Promise<boolean>
   updatePayment(paymentId: string, json: UpdatePayment): Promise<Payment | null>
 }
 
@@ -58,10 +58,10 @@ export class AdminService implements AdminAPI {
       .json<Payments>()
   }
 
-  async revokePack(packId: string): Promise<boolean> {
+  async revokePack(packId: string, ownerId: string): Promise<boolean> {
     return await this.http
-      .patch(urls.api.v1.admin.revokePack, {
-        json: { packId },
+      .post(urls.api.v1.admin.revokePack, {
+        json: { packId, ownerId },
       })
       .then((response) => response.ok)
   }

--- a/apps/web/src/services/admin-service.ts
+++ b/apps/web/src/services/admin-service.ts
@@ -13,6 +13,7 @@ import { urls } from '@/utils/urls'
 export interface AdminAPI {
   getLoggedInUserPermissions(): Promise<AdminPermissions>
   getPaymentsByBankAccountId(bankAccountId: string): Promise<Payments>
+  revokePack: (packId: string) => Promise<boolean>
   updatePayment(paymentId: string, json: UpdatePayment): Promise<Payment | null>
 }
 
@@ -55,6 +56,14 @@ export class AdminService implements AdminAPI {
         `${urls.api.v1.admin.getPaymentsForBankAccount}?bankAccountId=${bankAccountId}`
       )
       .json<Payments>()
+  }
+
+  async revokePack(packId: string): Promise<boolean> {
+    return await this.http
+      .patch(urls.api.v1.admin.revokePack, {
+        json: { packId },
+      })
+      .then((response) => response.ok)
   }
 
   async updatePayment(

--- a/apps/web/src/services/admin-service.ts
+++ b/apps/web/src/services/admin-service.ts
@@ -1,7 +1,7 @@
 import {
   AdminPermissions,
   Payment,
-  Payments,
+  ToPaymentBase,
   UpdatePayment,
 } from '@algomart/schemas'
 import { getAuth } from 'firebase/auth'
@@ -12,7 +12,7 @@ import { urls } from '@/utils/urls'
 
 export interface AdminAPI {
   getLoggedInUserPermissions(): Promise<AdminPermissions>
-  getPaymentsByBankAccountId(bankAccountId: string): Promise<Payments>
+  getPaymentsByBankAccountId(bankAccountId: string): Promise<ToPaymentBase[]>
   revokePack: (packId: string, ownerId: string) => Promise<boolean>
   updatePayment(paymentId: string, json: UpdatePayment): Promise<Payment | null>
 }
@@ -50,12 +50,14 @@ export class AdminService implements AdminAPI {
     return response
   }
 
-  async getPaymentsByBankAccountId(bankAccountId: string): Promise<Payments> {
+  async getPaymentsByBankAccountId(
+    bankAccountId: string
+  ): Promise<ToPaymentBase[]> {
     return await this.http
       .get(
         `${urls.api.v1.admin.getPaymentsForBankAccount}?bankAccountId=${bankAccountId}`
       )
-      .json<Payments>()
+      .json<ToPaymentBase[]>()
   }
 
   async revokePack(packId: string, ownerId: string): Promise<boolean> {

--- a/apps/web/src/services/checkout-service.ts
+++ b/apps/web/src/services/checkout-service.ts
@@ -139,14 +139,6 @@ export class CheckoutService implements CheckoutAPI {
       .json<Payments>()
   }
 
-  async getPaymentsByBankAccountId(bankAccountId: string): Promise<Payments> {
-    return await this.http
-      .get(
-        `${urls.api.v1.admin.getPaymentsForBankAccount}?bankAccountId=${bankAccountId}`
-      )
-      .json<Payments>()
-  }
-
   async getPayment(paymentId: string): Promise<Payment> {
     const response = await this.http.get(
       `${urls.api.v1.getPayment}?paymentId=${paymentId}`

--- a/apps/web/src/services/checkout-service.ts
+++ b/apps/web/src/services/checkout-service.ts
@@ -1,6 +1,4 @@
 import {
-  AdminPaymentList,
-  AdminPaymentListQuerystring,
   CreateBankAccountResponse,
   CreatePaymentCard,
   GetPaymentBankAccountStatus,
@@ -8,6 +6,8 @@ import {
   Payment,
   PaymentBankAccountInstructions,
   PaymentCards,
+  Payments,
+  PaymentsQuerystring,
   PublicKey,
   ToPaymentBase,
 } from '@algomart/schemas'
@@ -45,7 +45,7 @@ export interface CheckoutAPI {
     bankAccountId: string
   ): Promise<GetPaymentBankAccountStatus>
   getCardStatus(cardId: string): Promise<GetPaymentCardStatus>
-  getPayments(query: AdminPaymentListQuerystring): Promise<AdminPaymentList>
+  getPayments(query: PaymentsQuerystring): Promise<Payments>
   getPayment(paymentId: string): Promise<Payment>
   getCards(): Promise<PaymentCards>
   getPublicKey(): Promise<PublicKey | null>
@@ -132,23 +132,19 @@ export class CheckoutService implements CheckoutAPI {
     return response.id && response.packId ? response : null
   }
 
-  async getPayments(
-    query: AdminPaymentListQuerystring
-  ): Promise<AdminPaymentList> {
+  async getPayments(query: PaymentsQuerystring): Promise<Payments> {
     const searchQuery = getPaymentsFilterQuery(query)
     return await this.http
       .get(`${urls.api.v1.listPayments}?${searchQuery}`)
-      .json<AdminPaymentList>()
+      .json<Payments>()
   }
 
-  async getPaymentsByBankAccountId(
-    bankAccountId: string
-  ): Promise<AdminPaymentList> {
+  async getPaymentsByBankAccountId(bankAccountId: string): Promise<Payments> {
     return await this.http
       .get(
         `${urls.api.v1.admin.getPaymentsForBankAccount}?bankAccountId=${bankAccountId}`
       )
-      .json<AdminPaymentList>()
+      .json<Payments>()
   }
 
   async getPayment(paymentId: string): Promise<Payment> {

--- a/apps/web/src/utils/asset-validation.ts
+++ b/apps/web/src/utils/asset-validation.ts
@@ -72,6 +72,11 @@ export const validateClaimAsset = (t: Translate) =>
     packTemplateId: packTemplateId(t),
   })
 
+export const validateRevokeAsset = (t: Translate) =>
+  object({
+    packId: packId(t),
+  })
+
 export const validateExportAsset = (t: Translate) =>
   object({
     address: string(required(t('forms:errors.required') as string)),

--- a/apps/web/src/utils/asset-validation.ts
+++ b/apps/web/src/utils/asset-validation.ts
@@ -75,6 +75,7 @@ export const validateClaimAsset = (t: Translate) =>
 export const validateRevokeAsset = (t: Translate) =>
   object({
     packId: packId(t),
+    ownerId: string(required(t('forms:errors.required') as string)),
   })
 
 export const validateExportAsset = (t: Translate) =>

--- a/apps/web/src/utils/filters.ts
+++ b/apps/web/src/utils/filters.ts
@@ -1,9 +1,9 @@
 import {
-  AdminPaymentListQuerystring,
   CollectibleListQuerystring,
   PacksByOwnerQuery,
   PackStatus,
   PackType,
+  PaymentsQuerystring,
   PublishedPacksQuery,
   SortOptions,
 } from '@algomart/schemas'
@@ -101,7 +101,7 @@ export const getCollectiblesFilterQuery = (
 /**
  * Build a search parameter string to filter payments
  */
-export const getPaymentsFilterQuery = (query: AdminPaymentListQuerystring) => {
+export const getPaymentsFilterQuery = (query: PaymentsQuerystring) => {
   return stringify({
     page: query.page,
     pageSize: query.pageSize || PAGE_SIZE,

--- a/apps/web/src/utils/urls.ts
+++ b/apps/web/src/utils/urls.ts
@@ -42,6 +42,7 @@ export const urls = {
         getPaymentsForBankAccount:
           '/api/v1/payments/get-payments-by-bank-account',
         getPayments: '/api/v1/payments/list-payments',
+        revokePack: '/api/v1/asset/revoke',
         updatePayment: '/api/v1/payments/update-payment',
       },
       addToShowcase: '/api/v1/collection/add-showcase',

--- a/libs/schemas/src/packs.ts
+++ b/libs/schemas/src/packs.ts
@@ -82,6 +82,7 @@ export const ClaimPackSchema = Type.Object({
 export const RevokePackSchema = Type.Object({
   packId: IdSchema,
   ownerId: Type.Optional(Nullable(IdSchema)),
+  fromAddress: Type.Optional(Nullable(Type.String())),
 })
 
 export const PackConfigSchema = Type.Object({

--- a/libs/schemas/src/packs.ts
+++ b/libs/schemas/src/packs.ts
@@ -179,6 +179,7 @@ export const PackWithIdSchema = Type.Intersect([
   Type.Object({
     id: IdSchema,
     activeBidId: Type.Optional(IdSchema),
+    ownerId: Type.Optional(IdSchema),
   }),
 ])
 

--- a/libs/schemas/src/packs.ts
+++ b/libs/schemas/src/packs.ts
@@ -79,6 +79,11 @@ export const ClaimPackSchema = Type.Object({
   claimedAt: Type.Optional(Nullable(Type.String({ format: 'date-time' }))),
 })
 
+export const RevokePackSchema = Type.Object({
+  packId: IdSchema,
+  ownerId: Type.Optional(Nullable(IdSchema)),
+})
+
 export const PackConfigSchema = Type.Object({
   collectibleDistribution: Type.Enum(PackCollectibleDistribution),
   collectibleOrder: Type.Enum(PackCollectibleOrder),
@@ -267,6 +272,7 @@ export type PublishedPacksQuery = Simplify<
 export type PublishedPack = Simplify<Static<typeof PublishedPackSchema>>
 export type PublishedPacks = Simplify<Static<typeof PublishedPacksSchema>>
 export type RedeemCode = Simplify<Static<typeof RedeemCodeSchema>>
+export type RevokePack = Simplify<Static<typeof RevokePackSchema>>
 export type TransferPack = Simplify<Static<typeof TransferPackSchema>>
 export type MintPack = Simplify<Static<typeof MintPackSchema>>
 export type MintPackStatusResponse = Simplify<

--- a/libs/schemas/src/payments.ts
+++ b/libs/schemas/src/payments.ts
@@ -594,7 +594,7 @@ export const PaymentQuerystringSchema = Type.Object({
 export const PaymentSchema = Type.Intersect([
   BaseSchema,
   PaymentBaseSchema,
-  Type.Omit(ToPaymentBaseSchema, ['externalId', 'amount']),
+  Type.Omit(ToPaymentBaseSchema, ['externalId', 'amount', 'error']),
   Type.Object({
     externalId: Type.Optional(Type.String({ format: 'uuid' })),
     amount: Type.Optional(Type.String()),

--- a/libs/schemas/src/payments.ts
+++ b/libs/schemas/src/payments.ts
@@ -596,7 +596,7 @@ export const PaymentSchema = Type.Intersect([
   PaymentBaseSchema,
   Type.Omit(ToPaymentBaseSchema, ['externalId', 'amount', 'error']),
   Type.Object({
-    externalId: Type.Optional(Type.String({ format: 'uuid' })),
+    externalId: Nullable(Type.Optional(Type.String({ format: 'uuid' }))),
     amount: Type.Optional(Type.String()),
     sourceId: Type.Optional(Type.String()),
     pack: Type.Optional(PackWithIdSchema),

--- a/libs/schemas/src/payments.ts
+++ b/libs/schemas/src/payments.ts
@@ -222,7 +222,7 @@ export const ToPaymentBaseSchema = Type.Object({
     ])
   ),
   amount: Type.String(),
-  sourceId: Type.Optional(Type.String({ format: 'uuid' })),
+  sourceId: Type.Optional(Type.String()),
 })
 
 const PaymentBaseSchema = Type.Object({
@@ -546,42 +546,6 @@ const CoinbaseErrorResponseSchema = Type.Object({
 // #endregion
 // #region Payment/card routes schemas
 
-export const AdminPaymentListQuerystringSchema = Type.Intersect([
-  PaginationSchema,
-  Type.Object({
-    locale: Type.Optional(Type.String()),
-    packId: Type.Optional(Type.String({ format: 'uuid' })),
-    packSlug: Type.Optional(Type.String()),
-    payerExternalId: Type.Optional(Type.String()),
-    payerUsername: Type.Optional(Type.String()),
-    sortBy: Type.Optional(
-      Type.Enum(PaymentSortField, { default: PaymentSortField.UpdatedAt })
-    ),
-    sortDirection: Type.Optional(
-      Type.Enum(SortDirection, { default: SortDirection.Ascending })
-    ),
-  }),
-])
-
-export const AdminPaymentBaseSchema = Type.Intersect([
-  BaseSchema,
-  Type.Object({
-    packId: Type.Optional(Nullable(Type.String({ format: 'uuid' }))),
-    pack: Type.Optional(PackWithIdSchema),
-    payerId: Type.String(),
-    paymentCardId: Type.Optional(Nullable(Type.String({ format: 'uuid' }))),
-    paymentBankId: Type.Optional(Nullable(Type.String({ format: 'uuid' }))),
-    destinationAddress: Type.Optional(Nullable(Type.String())),
-    status: Type.Optional(Type.Enum(PaymentStatus)),
-    transferId: Type.Optional(Nullable(Type.String())),
-  }),
-])
-
-export const AdminPaymentListSchema = Type.Object({
-  payments: Type.Array(AdminPaymentBaseSchema),
-  total: Type.Number(),
-})
-
 export const CurrencySchema = Type.Object({
   base: Type.Number(),
   code: Type.String(),
@@ -623,18 +587,47 @@ export const GetPaymentCardStatusSchema = Type.Object({
   status: Type.Optional(Type.Enum(PaymentCardStatus)),
 })
 
+export const PaymentQuerystringSchema = Type.Object({
+  isAdmin: Type.Optional(Type.Boolean()),
+})
+
 export const PaymentSchema = Type.Intersect([
   BaseSchema,
   PaymentBaseSchema,
-  Type.Omit(ToPaymentBaseSchema, ['externalId', 'amount', 'sourceId']),
+  Type.Omit(ToPaymentBaseSchema, ['externalId', 'amount']),
   Type.Object({
-    externalId: Nullable(Type.String({ format: 'uuid' })),
+    externalId: Type.Optional(Type.String({ format: 'uuid' })),
+    amount: Type.Optional(Type.String()),
+    sourceId: Type.Optional(Type.String()),
+    pack: Type.Optional(PackWithIdSchema),
   }),
 ])
 
 export const PaymentIdSchema = Type.Object({
   paymentId: Type.String(),
 })
+
+export const PaymentsSchema = Type.Object({
+  payments: Type.Array(PaymentSchema),
+  total: Type.Number(),
+})
+
+export const PaymentsQuerystringSchema = Type.Intersect([
+  PaginationSchema,
+  Type.Object({
+    locale: Type.Optional(Type.String()),
+    packId: Type.Optional(Type.String({ format: 'uuid' })),
+    packSlug: Type.Optional(Type.String()),
+    payerExternalId: Type.Optional(Type.String()),
+    payerUsername: Type.Optional(Type.String()),
+    sortBy: Type.Optional(
+      Type.Enum(PaymentSortField, { default: PaymentSortField.UpdatedAt })
+    ),
+    sortDirection: Type.Optional(
+      Type.Enum(SortDirection, { default: SortDirection.Ascending })
+    ),
+  }),
+])
 
 export const PaymentCardSchema = Type.Intersect([
   BaseSchema,
@@ -732,10 +725,6 @@ export const UpdatePaymentCardSchema = Type.Object({
 // #endregion
 // #region Types
 
-export type AdminPaymentList = Simplify<Static<typeof AdminPaymentListSchema>>
-export type AdminPaymentListQuerystring = Simplify<
-  Static<typeof AdminPaymentListQuerystringSchema>
->
 export type BankAccountId = Simplify<Static<typeof BankAccountIdSchema>>
 export type CardId = Simplify<Static<typeof CardIdSchema>>
 export type CircleBlockchainAddress = Simplify<
@@ -812,7 +801,6 @@ export type GetPaymentBankAccountStatus = Simplify<
 export type GetPaymentCardStatus = Simplify<
   Static<typeof GetPaymentCardStatusSchema>
 >
-export type AdminPaymentBase = Simplify<Static<typeof AdminPaymentBaseSchema>>
 export type Payment = Simplify<Static<typeof PaymentSchema>>
 export type PaymentId = Simplify<Static<typeof PaymentIdSchema>>
 export type PaymentBankAccount = Simplify<
@@ -823,6 +811,13 @@ export type PaymentBankAccountInstructions = Simplify<
 >
 export type PaymentCard = Simplify<Static<typeof PaymentCardSchema>>
 export type PaymentCards = Simplify<Static<typeof PaymentCardsSchema>>
+export type PaymentQuerystring = Simplify<
+  Static<typeof PaymentQuerystringSchema>
+>
+export type Payments = Simplify<Static<typeof PaymentsSchema>>
+export type PaymentsQuerystring = Simplify<
+  Static<typeof PaymentsQuerystringSchema>
+>
 export type PublicKey = Simplify<Static<typeof PublicKeySchema>>
 export type SendBankAccountInstructions = Simplify<
   Static<typeof SendBankAccountInstructionsSchema>

--- a/libs/schemas/src/payments.ts
+++ b/libs/schemas/src/payments.ts
@@ -1,5 +1,6 @@
 import { Static, Type } from '@sinclair/typebox'
 
+import { UserAccountSchema } from './accounts'
 import { PackWithIdSchema } from './packs'
 import {
   BaseSchema,
@@ -600,6 +601,7 @@ export const PaymentSchema = Type.Intersect([
     amount: Type.Optional(Type.String()),
     sourceId: Type.Optional(Type.String()),
     pack: Type.Optional(PackWithIdSchema),
+    payer: Type.Optional(UserAccountSchema),
   }),
 ])
 


### PR DESCRIPTION
### Changes
- Collectible service method for transferring from the user account to the creator account.
- Clawback method for revoking from the user to the creator account
- Revoke pack method in the pack service that revokes the claim and transfers the asset back to the creator account. 
- [ ] Determining when to enable/disable buttons/functionality based on the current state of the payment. 
- [ ] User notification emails

Closes #269
