### PR TITLE
Notifications

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -30,6 +30,8 @@ CIRCLE_URL=https://api-sandbox.circle.com
 EMAIL_FROM=
 EMAIL_NAME=AlgoMart
 
+CUSTOMER_SERVICE_EMAIL=
+
 # Supported transports: smtp, sendgrid
 EMAIL_TRANSPORT=smtp
 

--- a/apps/api/src/configuration/index.ts
+++ b/apps/api/src/configuration/index.ts
@@ -136,6 +136,10 @@ export const Configuration = {
     return Currencies[code as keyof typeof Currencies]
   },
 
+  get customerServiceEmail() {
+    return env.get('CUSTOMER_SERVICE_EMAIL').asString()
+  },
+
   get mailer(): MailerAdapterOptions {
     const emailFrom =
       env.get('EMAIL_FROM').default('').asString() ||

--- a/apps/api/src/locales/en-US/emails.json
+++ b/apps/api/src/locales/en-US/emails.json
@@ -58,7 +58,7 @@
     "subject": "Congratulations on your purchase!",
     "body": [
       "Congratulations on your purchase of {{packTitle}}!",
-      "Here's the bank account information for the wire transfer of {{amount}}:",
+      "Here's the bank account information for the wire transfer of ${{amount}}:",
       "<strong>Beneficiary:</strong>",
       "Name: {{beneficiaryName}}",
       "Address: {{beneficiaryAddress1}} {{beneficiaryAddress2}}",

--- a/apps/api/src/locales/en-US/emails.json
+++ b/apps/api/src/locales/en-US/emails.json
@@ -75,5 +75,17 @@
       "<a href=\"{{ctaUrl}}\"><strong>View listing</strong></a>"
     ],
     "expirationWarning": "<em>Note: You have 72 hours before your winning bid expires and goes to the next highest bidder.</em>"
+  },
+  "csAwaitingWirePayment": {
+    "subject": "AWAITING wire payment for “{{packTitle}}”",
+    "body": "Awaiting wire payment of ${{amount}} for “{{packTitle}}” by {{userEmail}}."
+  },
+  "csWirePaymentFailed": {
+    "subject": "Wire payment FAILED for “{{packTitle}}”",
+    "body": "Wire payment of ${{amount}} for “{{packTitle}}” by {{userEmail}} failed."
+  },
+  "csWirePaymentSuccess": {
+    "subject": "Wire payment SUCCESS for “{{packTitle}}”",
+    "body": "Wire payment of ${{amount}} for “{{packTitle}}” by {{userEmail}} succeeded."
   }
 }

--- a/apps/api/src/locales/en-US/emails.json
+++ b/apps/api/src/locales/en-US/emails.json
@@ -14,6 +14,14 @@
       "We're writing to let you know that your bid for “{{packTitle}}” has expired since no payment has been received."
     ]
   },
+  "packRevoked": {
+    "subject": "Pack revoked",
+    "body": "Your pack “{{packTitle}}” has been revoked. Please contact customer support if you believe this to be in error."
+  },
+  "paymentFailed": {
+    "subject": "Payment failed",
+    "body": "Your payment for “{{packTitle}}” failed. Please contact customer support."
+  },
   "paymentSuccess": {
     "subject": "Your collectibles are ready!",
     "body": [

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -21,6 +21,17 @@ import { logger } from '@/utils/logger'
 const isResponseError = (error: unknown): error is ResponseError => {
   return typeof (error as ResponseError).response?.body === 'string'
 }
+
+const requireVariables = (variables, variableNames: string[]) => {
+  invariant(variables, 'no variables were provided for this notification')
+  for (const key of variableNames) {
+    invariant(
+      typeof variables[key] === 'string',
+      `variable '${key}' is required`
+    )
+  }
+}
+
 export default class NotificationsService {
   logger = logger.child({ context: this.constructor.name })
   dispatchStore: {
@@ -40,6 +51,13 @@ export default class NotificationsService {
     [NotificationType.UserOutbid]: this.getUserOutbidNotification.bind(this),
     [NotificationType.WireInstructions]:
       this.getWireInstructionsNotification.bind(this),
+    // Customer Service Notifications
+    [NotificationType.CSWirePaymentFailed]:
+      this.getCSWirePaymentFailedNotification.bind(this),
+    [NotificationType.CSWirePaymentSuccess]:
+      this.getCSWirePaymentSuccessNotification.bind(this),
+    [NotificationType.CSAwaitingWirePayment]:
+      this.getCSAwaitingWirePaymentNotification.bind(this),
   }
 
   constructor(
@@ -73,18 +91,20 @@ export default class NotificationsService {
     let successfullyDispatchedNotifications = 0
     await Promise.all(
       pendingNotifications.map(async (notification) => {
-        // Ensure recipient
-        if (!notification?.userAccount?.email) {
-          throw new Error(`Notification "${notification.id}" has no recipient`)
-        }
+        // Note: For customer service notifications this is not the recipient
+        // but the customer who the notification pertains to.
+        invariant(
+          notification?.userAccount?.email,
+          `Notification "${notification.id}" has no associated user account`
+        )
 
-        // Get recipient's locale
         const {
           type,
           id,
           userAccountId,
           userAccount: { locale },
         } = notification
+        // Get user's locale
         const t = this.i18n.getFixedT(locale, 'emails')
 
         // Attempt to send notification
@@ -107,13 +127,12 @@ export default class NotificationsService {
 
   getAuctionCompleteNotification(n: NotificationModel, t: TFunction): Email {
     const { userAccount, variables } = n
-
-    // Validate variables
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(typeof variables.amount === 'string', 'amount is required')
-    invariant(typeof variables.canExpire === 'boolean', 'canExpire is required')
-    invariant(typeof variables.packSlug === 'string', 'packSlug is required')
-    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
+    requireVariables(variables, [
+      'amount',
+      'canExpire',
+      'packSlug',
+      'packTitle',
+    ])
 
     // Build notification
     const body = (
@@ -128,23 +147,18 @@ export default class NotificationsService {
       ? body + `<p>${t('auctionComplete.expirationWarning')}</p>`
       : body
 
-    const message = {
+    return {
       to: userAccount?.email as string,
       subject: t('auctionComplete.subject'),
       html,
     }
-    return message
   }
 
   getBidExpiredNotification(n: NotificationModel, t: TFunction): Email {
     const { userAccount, variables } = n
+    requireVariables(variables, ['packTitle'])
 
-    // Validate variables
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
-
-    // Build notification
-    const message = {
+    return {
       to: userAccount?.email as string,
       subject: t('bidExpired.subject', { ...variables }),
       html: t<string[]>('bidExpired.body', {
@@ -152,16 +166,11 @@ export default class NotificationsService {
         ...variables,
       }).reduce((body: string, p: string) => body + `<p>${p}</p>`, ''),
     }
-
-    return message
   }
 
   getPaymentSuccessNotification(n: NotificationModel, t: TFunction): Email {
     const { userAccount, variables } = n
-
-    // Validate variables
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
+    requireVariables(variables, ['packTitle'])
 
     const html = t<string[]>('paymentSuccess.body', {
       returnObjects: true,
@@ -169,21 +178,16 @@ export default class NotificationsService {
       ...variables,
     })
 
-    // Build notification
-    const message = {
+    return {
       to: userAccount?.email as string,
       subject: t('paymentSuccess.subject'),
       html: html.reduce((body: string, p: string) => body + `<p>${p}</p>`, ''),
     }
-    return message
   }
 
   getTransferSuccessNotification(n: NotificationModel, t: TFunction): Email {
     const { userAccount, variables } = n
-
-    // Validate variables
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
+    requireVariables(variables, ['packTitle'])
 
     const html = t<string[]>('transferSuccess.body', {
       returnObjects: true,
@@ -191,25 +195,18 @@ export default class NotificationsService {
       ...variables,
     })
 
-    // Build notification
-    const message = {
+    return {
       to: userAccount?.email as string,
       subject: t('transferSuccess.subject'),
       html: html.reduce((body: string, p: string) => body + `<p>${p}</p>`, ''),
     }
-    return message
   }
 
   getUserHighBidNotification(n: NotificationModel, t: TFunction): Email {
     const { userAccount, variables } = n
+    requireVariables(variables, ['packTitle', 'packSlug'])
 
-    // Validate variables
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(typeof variables.packSlug === 'string', 'packSlug is required')
-    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
-
-    // Build notification
-    const message = {
+    return {
       to: userAccount?.email as string,
       subject: t('userHighBid.subject'),
       html: (
@@ -220,19 +217,13 @@ export default class NotificationsService {
         }) as string[]
       ).reduce((body: string, p: string) => body + `<p>${p}</p>`, ''),
     }
-    return message
   }
 
   getUserOutbidNotification(n: NotificationModel, t: TFunction) {
     const { userAccount, variables } = n
+    requireVariables(variables, ['packTitle', 'packSlug'])
 
-    // Validate variables
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(typeof variables.packSlug === 'string', 'packSlug is required')
-    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
-
-    // Build notification
-    const message = {
+    return {
       to: userAccount?.email as string,
       subject: t('userOutbid.subject'),
       html: (
@@ -243,62 +234,27 @@ export default class NotificationsService {
         }) as string[]
       ).reduce((body: string, p: string) => body + `<p>${p}</p>`, ''),
     }
-    return message
   }
 
   getWireInstructionsNotification(n: NotificationModel, t: TFunction) {
     const { userAccount, variables } = n
-
-    // Validate variables
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(
-      typeof variables.trackingRef === 'string',
-      'trackingRef is required'
-    )
-    invariant(
-      typeof variables.beneficiaryName === 'string',
-      'beneficiaryName is required'
-    )
-    invariant(
-      typeof variables.beneficiaryAddress1 === 'string',
-      'beneficiaryAddress1 is required'
-    )
-    invariant(
-      typeof variables.beneficiaryAddress2 === 'string',
-      'beneficiaryAddress2 is required'
-    )
-    invariant(
-      typeof variables.beneficiaryBankName === 'string',
-      'beneficiaryBankName is required'
-    )
-    invariant(
-      typeof variables.beneficiaryBankSwiftCode === 'string',
-      'beneficiaryBankSwiftCode is required'
-    )
-    invariant(
-      typeof variables.beneficiaryBankRoutingNumber === 'string',
-      'beneficiaryBankRoutingNumber is required'
-    )
-    invariant(
-      typeof variables.beneficiaryBankAccountingNumber === 'string',
-      'beneficiaryBankAccountingNumber is required'
-    )
-    invariant(
-      typeof variables.beneficiaryBankAddress === 'string',
-      'beneficiaryBankAddress is required'
-    )
-    invariant(
-      typeof variables.beneficiaryBankCity === 'string',
-      'beneficiaryBankCity is required'
-    )
-    invariant(
-      typeof variables.beneficiaryBankPostalCode === 'string',
-      'beneficiaryBankPostalCode is required'
-    )
-    invariant(
-      typeof variables.beneficiaryBankCountry === 'string',
-      'beneficiaryBankCountry is required'
-    )
+    requireVariables(variables, [
+      'packTitle',
+      'amount',
+      'beneficiaryName',
+      'beneficiaryAddress1',
+      'beneficiaryAddress2',
+      'beneficiaryBankName',
+      'beneficiaryBankSwiftCode',
+      'beneficiaryBankRoutingNumber',
+      'beneficiaryBankAccountingNumber',
+      'beneficiaryBankAddress',
+      'beneficiaryBankCity',
+      'beneficiaryBankPostalCode',
+      'beneficiaryBankCountry',
+      'trackingRef',
+      'ctaUrl',
+    ])
 
     // Build notification
     const body = (
@@ -313,19 +269,16 @@ export default class NotificationsService {
       ? body + `<p>${t('wireTransfer.expirationWarning')}</p>`
       : body
 
-    const message = {
+    return {
       to: userAccount?.email as string,
       subject: t('wireTransfer.subject'),
       html,
     }
-
-    return message
   }
 
   getPaymentFailedNotification(n: NotificationModel, t: TFunction) {
     const { userAccount, variables } = n
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
+    requireVariables(variables, ['packTitle'])
     return {
       to: userAccount?.email,
       subject: t('paymentFailed.subject'),
@@ -335,12 +288,49 @@ export default class NotificationsService {
 
   getPackRevokedNotification(n: NotificationModel, t: TFunction) {
     const { userAccount, variables } = n
-    invariant(variables, 'no variables were provided for this notification')
-    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
+    requireVariables(variables, ['packTitle'])
     return {
       to: userAccount?.email,
       subject: t('packRevoked.subject'),
       html: t('packRevoked.body', variables),
+    }
+  }
+
+  // Automated Emails to Customer Service
+
+  getCSWirePaymentFailedNotification(n: NotificationModel, t: TFunction) {
+    const { userAccount, variables } = n
+    const variables_ = { ...variables, userEmail: userAccount?.email }
+    requireVariables(variables_, ['packTitle', 'userEmail', 'amount'])
+    return {
+      to: Configuration.customerServiceEmail,
+      subject: t('csWirePaymentFailed.subject', variables_),
+      html: t('csWirePaymentFailed.body', variables_),
+    }
+  }
+
+  getCSWirePaymentSuccessNotification(n: NotificationModel, t: TFunction) {
+    const { userAccount, variables } = n
+    const variables_ = { ...variables, userEmail: userAccount?.email }
+    requireVariables(variables_, ['packTitle', 'userEmail', 'amount'])
+    return {
+      to: Configuration.customerServiceEmail,
+      subject: t('csWirePaymentSuccess.subject', variables_),
+      html: t('csWirePaymentSuccess.body', variables_),
+    }
+  }
+
+  getCSAwaitingWirePaymentNotification(n: NotificationModel, t: TFunction) {
+    const { userAccount, variables } = n
+    const variables_ = {
+      ...variables,
+      userEmail: userAccount?.email,
+    }
+    requireVariables(variables_, ['packTitle', 'userEmail', 'amount'])
+    return {
+      to: Configuration.customerServiceEmail,
+      subject: t('csAwaitingWirePayment.subject', variables_),
+      html: t('csAwaitingWirePayment.body', variables_),
     }
   }
 

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -28,6 +28,9 @@ export default class NotificationsService {
   } = {
     [NotificationType.AuctionComplete]:
       this.getAuctionCompleteNotification.bind(this),
+    [NotificationType.PackRevoked]: this.getPackRevokedNotification.bind(this),
+    [NotificationType.PaymentFailed]:
+      this.getPaymentFailedNotification.bind(this),
     [NotificationType.BidExpired]: this.getBidExpiredNotification.bind(this),
     [NotificationType.PaymentSuccess]:
       this.getPaymentSuccessNotification.bind(this),
@@ -317,6 +320,28 @@ export default class NotificationsService {
     }
 
     return message
+  }
+
+  getPaymentFailedNotification(n: NotificationModel, t: TFunction) {
+    const { userAccount, variables } = n
+    invariant(variables, 'no variables were provided for this notification')
+    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
+    return {
+      to: userAccount?.email,
+      subject: t('paymentFailed.subject'),
+      html: t('paymentFailed.body', variables),
+    }
+  }
+
+  getPackRevokedNotification(n: NotificationModel, t: TFunction) {
+    const { userAccount, variables } = n
+    invariant(variables, 'no variables were provided for this notification')
+    invariant(typeof variables.packTitle === 'string', 'packTitle is required')
+    return {
+      to: userAccount?.email,
+      subject: t('packRevoked.subject'),
+      html: t('packRevoked.body', variables),
+    }
   }
 
   async sendNotification(

--- a/apps/api/src/modules/packs/packs.service.ts
+++ b/apps/api/src/modules/packs/packs.service.ts
@@ -904,7 +904,16 @@ export default class PacksService {
     // Create transfer success notification to be sent to user
     const packWithBase = await this.getPackById(request.packId)
     if (packWithBase) {
-      // @TODO: create notification for revoking the pack
+      await this.notifications.createNotification(
+        {
+          type: NotificationType.PackRevoked,
+          userAccountId: request.ownerId,
+          variables: {
+            packTitle: packWithBase.title,
+          },
+        },
+        trx
+      )
     }
 
     // Remove claim from pack

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -27,6 +27,7 @@ import {
   UserAccount,
   WirePayment,
 } from '@algomart/schemas'
+import { env } from 'node:process'
 import { Transaction } from 'objection'
 
 import { Configuration } from '@/configuration'
@@ -736,7 +737,54 @@ export default class PaymentsService {
         externalId: sourcePayment.externalId,
         status: sourcePayment.status,
       })
+      // Send Awaiting payment notification to customer service
+      if (Configuration.customerServiceEmail) {
+        const packTemplate = await this.packs.getPackById(payment.packId)
+        await this.notifications.createNotification(
+          {
+            type: NotificationType.CSAwaitingWirePayment,
+            userAccountId: payment.payerId,
+            variables: {
+              packTitle: packTemplate.title,
+              amount: sourcePayment.amount,
+            },
+          },
+          trx
+        )
+      }
     }
+
+    // Send email notification to  Customer service
+    if (Configuration.customerServiceEmail) {
+      if (sourcePayment.status === PaymentStatus.Failed) {
+        const packTemplate = await this.packs.getPackById(payment.packId)
+        await this.notifications.createNotification(
+          {
+            type: NotificationType.CSWirePaymentFailed,
+            userAccountId: payment.payerId,
+            variables: {
+              packTitle: packTemplate.title,
+              amount: sourcePayment.amount,
+            },
+          },
+          trx
+        )
+      } else if (sourcePayment.status === PaymentStatus.Paid) {
+        const packTemplate = await this.packs.getPackById(payment.packId)
+        await this.notifications.createNotification(
+          {
+            type: NotificationType.CSWirePaymentSuccess,
+            userAccountId: payment.payerId,
+            variables: {
+              packTitle: packTemplate.title,
+              amount: sourcePayment.amount,
+            },
+          },
+          trx
+        )
+      }
+    }
+
     return sourcePayment
   }
 
@@ -804,32 +852,6 @@ export default class PaymentsService {
       entityType: EventEntityType.Payment,
       entityId: paymentId,
     })
-
-    const packTemplate = await this.packs.getPackById(payment.packId)
-
-    if (updatedDetails.status === PaymentStatus.Failed) {
-      await this.notifications.createNotification(
-        {
-          type: NotificationType.PaymentFailed,
-          userAccountId: payment.payerId,
-          variables: {
-            packTitle: packTemplate.title,
-          },
-        },
-        trx
-      )
-    } else if (updatedDetails.status === PaymentStatus.Paid) {
-      await this.notifications.createNotification(
-        {
-          type: NotificationType.PaymentSuccess,
-          userAccountId: payment.payerId,
-          variables: {
-            packTitle: packTemplate.title,
-          },
-        },
-        trx
-      )
-    }
 
     return payment
   }
@@ -939,6 +961,7 @@ export default class PaymentsService {
     await Promise.all(
       pendingPayments.map(async (payment) => {
         let status: PaymentStatus | undefined
+
         // Card flow
         if (payment.externalId && payment.paymentCardId) {
           const circlePayment = await this.circle.getPaymentById(
@@ -982,15 +1005,35 @@ export default class PaymentsService {
             updatedPayments++
           }
         }
+
         // If the new payment status is resolved as Paid:
         if (status === PaymentStatus.Paid && payment.packId) {
-          // @TODO: Take action if payment is successful
+          const packTemplate = await this.packs.getPackById(payment.packId)
+          await this.notifications.createNotification(
+            {
+              type: NotificationType.PaymentSuccess,
+              userAccountId: payment.payerId,
+              variables: {
+                packTitle: packTemplate.title,
+              },
+            },
+            trx
+          )
         }
         // If the new payment status is resolved as Failed:
         if (status === PaymentStatus.Failed) {
-          // @TODO: Take action if payment fails
+          const packTemplate = await this.packs.getPackById(payment.packId)
+          await this.notifications.createNotification(
+            {
+              type: NotificationType.PaymentFailed,
+              userAccountId: payment.payerId,
+              variables: {
+                packTitle: packTemplate.title,
+              },
+            },
+            trx
+          )
         }
-        return
       })
     )
 

--- a/apps/cms/snapshot.yml
+++ b/apps/cms/snapshot.yml
@@ -2090,6 +2090,15 @@ fields:
       conditions: null
       required: false
       group: null
+      conditions:
+        - name: No editing after publish
+          rule:
+            _and:
+              - status:
+                  _eq: published
+              - id:
+                  _nnull: true
+          readonly: true
   - collection: nft_templates
     field: preview_video
     type: uuid

--- a/apps/web/src/components/button.tsx
+++ b/apps/web/src/components/button.tsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx'
 import { ButtonHTMLAttributes, DetailedHTMLProps, HTMLAttributes } from 'react'
 
-import { useThemeContext } from '@/contexts/theme-context'
+import EllipsisLoader from '@/components/ellipsis-loader'
 
 export interface ButtonBaseProps {
+  busy?: boolean
   disablePadding?: boolean
   size?: 'small' | 'medium'
   variant?: 'primary' | 'secondary' | 'tertiary' | 'link'
@@ -19,6 +20,7 @@ export function buttonClasses(
   props: ButtonBaseProps & { disabled?: boolean; className?: string }
 ) {
   const {
+    busy,
     disablePadding,
     size,
     variant,
@@ -28,7 +30,7 @@ export function buttonClasses(
     group,
   } = props
   return clsx(
-    'duration-300 transition text-base-primaryText',
+    'duration-300 transition text-base-primaryText relative',
     {
       'rounded-sm': !group,
       'rounded-l-sm': group === 'left',
@@ -53,6 +55,7 @@ export function buttonClasses(
 }
 
 export default function Button({
+  busy,
   children,
   className,
   disabled = false,
@@ -76,12 +79,15 @@ export default function Button({
         variant,
         group,
       })}
-      disabled={disabled}
+      disabled={disabled || busy}
       onClick={onClick}
       type={type}
       {...props}
     >
-      {children}
+      <span className={busy && 'opacity-0'}>{children}</span>
+      {busy && (
+        <EllipsisLoader className="absolute bottom-0 left-0 right-0 -mt-4 top-1/2" />
+      )}
     </button>
   )
 }

--- a/apps/web/src/components/ellipsis-loader/ellipsis-loader.module.css
+++ b/apps/web/src/components/ellipsis-loader/ellipsis-loader.module.css
@@ -1,0 +1,29 @@
+@keyframes twinkle {
+  0% {
+    @apply opacity-20;
+  }
+  50% {
+    @apply scale-110 opacity-100 transform-gpu;
+  }
+  100% {
+    @apply opacity-20;
+  }
+}
+
+.inline {
+  @apply inline-block;
+}
+
+.dot {
+  @apply inline-block tracking-widest select-none opacity-20 transform-gpu;
+  transform-origin: 50% 72%;
+}
+.dot:nth-child(1) {
+  animation: twinkle 1s 0s infinite ease;
+}
+.dot:nth-child(2) {
+  animation: twinkle 1s 0.15s infinite ease;
+}
+.dot:nth-child(3) {
+  animation: twinkle 1s 0.3s infinite ease;
+}

--- a/apps/web/src/components/ellipsis-loader/index.tsx
+++ b/apps/web/src/components/ellipsis-loader/index.tsx
@@ -1,0 +1,29 @@
+import clsx from 'clsx'
+import React from 'react'
+
+import css from './ellipsis-loader.module.css'
+
+interface EllipsisLoaderProps {
+  inline?: boolean
+  className?: string
+}
+
+/**
+Simple animated ellipsis to show a loading state.
+Inherits it's font styles and color from the dom.
+*/
+const EllipsisLoader: React.FC<EllipsisLoaderProps> = ({
+  inline,
+  className,
+  ...rest
+}) => {
+  return (
+    <div className={clsx(className, { [css.inline]: inline })} {...rest}>
+      <div className={css.dot}>.</div>
+      <div className={css.dot}>.</div>
+      <div className={css.dot}>.</div>
+    </div>
+  )
+}
+
+export default EllipsisLoader

--- a/apps/web/src/pages/admin/transactions/transaction.module.css
+++ b/apps/web/src/pages/admin/transactions/transaction.module.css
@@ -24,3 +24,7 @@
 .userInfoPanel dd {
   @apply font-mono text-xs text-base-textTertiary;
 }
+
+.leftSide {
+  @apply w-64;
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3,68 +3,63 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Base styles */
-@layer base {
-  html,
-  body {
-    @apply h-full text-base-textPrimary bg-base-bg;
-    font-family: 'Inter', ui-sans-serif, system-ui, -apple-system !important;
-  }
+/* Default light theme */
+:root {
+  --textPrimary: 10, 17, 29;
+  --textSecondary: 44, 51, 63;
+  --textTertiary: 78, 85, 97;
+  --textDisabled: 102, 102, 102;
 
-  /* Default light theme */
-  :root {
-    --textPrimary: 10, 17, 29;
-    --textSecondary: 44, 51, 63;
-    --textTertiary: 78, 85, 97;
-    --textDisabled: 102, 102, 102;
+  --bg: 236, 236, 236;
+  --bgCard: 255, 255, 255;
+  --bgPanel: 255, 255, 255;
+  --bgNotice: 249, 249, 249;
 
-    --bg: 236, 236, 236;
-    --bgCard: 255, 255, 255;
-    --bgPanel: 255, 255, 255;
-    --bgNotice: 249, 249, 249;
+  --actionPrimary: 10, 17, 29; /* very dark gray-blue */
+  --actionPrimaryContrastText: 255, 255, 255;
+  --actionSecondary: 18, 220, 197; /* teal */
+  --actionSecondaryContrastText: 0, 0, 0;
+  --actionAccent: 2, 251, 194; /* light green */
 
-    --actionPrimary: 10, 17, 29; /* very dark gray-blue */
-    --actionPrimaryContrastText: 255, 255, 255;
-    --actionSecondary: 18, 220, 197; /* teal */
-    --actionSecondaryContrastText: 0, 0, 0;
-    --actionAccent: 2, 251, 194; /* light green */
+  --grayDark: 10, 17, 29; /* DEPRECATED */
+  --border: 218, 220, 223;
 
-    --grayDark: 10, 17, 29; /* DEPRECATED */
-    --border: 218, 220, 223;
+  --error: 172, 0, 0; /* red */
+  --price: 5, 150, 105; /* green-600 */
+}
 
-    --error: 172, 0, 0; /* red */
-    --price: 5, 150, 105; /* green-600 */
-  }
+/* Dark theme */
+.dark {
+  --textPrimary: 250, 250, 250;
+  --textSecondary: 216, 216, 216;
+  --textTertiary: 182, 182, 182;
+  --textDisabled: 128, 128, 128;
 
-  /* Dark theme */
-  .dark {
-    --textPrimary: 250, 250, 250;
-    --textSecondary: 216, 216, 216;
-    --textTertiary: 182, 182, 182;
-    --textDisabled: 128, 128, 128;
+  --bg: 34, 35, 39;
+  --bgCard: 9, 12, 13;
+  --bgPanel: 28, 29, 33;
+  --bgNotice: 28, 29, 33;
 
-    --bg: 34, 35, 39;
-    --bgCard: 9, 12, 13;
-    --bgPanel: 28, 29, 33;
-    --bgNotice: 28, 29, 33;
+  --actionPrimary: 253, 89, 132; /* hot pink */
+  --actionPrimaryContrastText: 255, 255, 255;
+  --actionSecondary: 18, 220, 197; /* teal */
+  --actionSecondaryContrastText: 0, 0, 0;
+  --actionAccent: 2, 251, 194; /* light green */
 
-    --actionPrimary: 253, 89, 132; /* hot pink */
-    --actionPrimaryContrastText: 255, 255, 255;
-    --actionSecondary: 18, 220, 197; /* teal */
-    --actionSecondaryContrastText: 0, 0, 0;
-    --actionAccent: 2, 251, 194; /* light green */
+  --grayDark: 10, 17, 29; /* DEPRECATED */
+  --border: 62, 64, 67;
 
-    --grayDark: 10, 17, 29; /* DEPRECATED */
-    --border: 62, 64, 67;
+  --error: 255, 70, 70; /* red */
+  --price: 35, 180, 135;
+}
 
-    --error: 255, 70, 70; /* red */
-    --price: 35, 180, 135;
-  }
+html,
+body {
+  @apply h-full text-base-textPrimary bg-base-bg;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system !important;
 }
 
 /* Custom globals  */
 #__next {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+  @apply flex flex-col h-full;
 }

--- a/libs/schemas/src/notifications.ts
+++ b/libs/schemas/src/notifications.ts
@@ -24,6 +24,9 @@ export enum NotificationType {
   UserHighBid = 'user-high-bid',
   UserOutbid = 'user-outbid',
   WireInstructions = 'wire-instructions',
+  CSWirePaymentFailed = 'cs-wire-payment-failed',
+  CSWirePaymentSuccess = 'cs-wire-payment-success',
+  CSAwaitingWirePayment = 'cs-awaiting-wire-payment',
 }
 
 export const CreateNotificationSchema = Type.Intersect([

--- a/libs/schemas/src/notifications.ts
+++ b/libs/schemas/src/notifications.ts
@@ -17,6 +17,8 @@ export enum NotificationStatus {
 export enum NotificationType {
   AuctionComplete = 'auction-complete',
   BidExpired = 'bid-expired',
+  PackRevoked = 'pack-revoked',
+  PaymentFailed = 'payment-failed',
   PaymentSuccess = 'payment-success',
   TransferSuccess = 'tranfer-success',
   UserHighBid = 'user-high-bid',


### PR DESCRIPTION
This adds user notifications for the following events:

- payment complete
- payment failed
- pack revoked

and customer service notifications for:

- awaiting wire payment
- wire payment success
- wire payment failure

Other changes
- add a `busy` prop to `Button` 
- attempt to fix the weird loss of theme styles issue we see from time to time with tailwind by moving the global css variables out of `@layer base`
- make NFT Template preview image read-only after publish