### PR TITLE
3DS fix

### DIFF
--- a/apps/api/src/modules/payments/index.ts
+++ b/apps/api/src/modules/payments/index.ts
@@ -8,7 +8,6 @@ import {
   CreatePaymentCardSchema,
   CreatePaymentSchema,
   CreateTransferPaymentSchema,
-  CreateWalletAddressSchema,
   CurrencySchema,
   FindTransferByAddressSchema,
   GetPaymentBankAccountStatusSchema,
@@ -282,7 +281,6 @@ export async function paymentRoutes(app: FastifyInstance) {
         schema: {
           tags,
           security,
-          body: CreateWalletAddressSchema,
           response: {
             201: CircleBlockchainAddressSchema,
           },

--- a/apps/api/src/modules/payments/payments.routes.ts
+++ b/apps/api/src/modules/payments/payments.routes.ts
@@ -5,7 +5,6 @@ import {
   CreateCard,
   CreatePayment,
   CreateTransferPayment,
-  CreateWalletAddress,
   FindTransferByAddress,
   OwnerExternalId,
   PaymentId,
@@ -175,15 +174,13 @@ export async function createCard(
 }
 
 export async function createWalletAddress(
-  request: FastifyRequest<{
-    Body: CreateWalletAddress
-  }>,
+  request: FastifyRequest,
   reply: FastifyReply
 ) {
   const paymentService = request
     .getContainer()
     .get<PaymentsService>(PaymentsService.name)
-  const address = await paymentService.generateAddress(request.body)
+  const address = await paymentService.generateAddress()
   if (address) {
     reply.status(201).send(address)
   } else {

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -623,6 +623,14 @@ export default class PaymentsService {
     )
     invariant(foundPayment, 'unable to find payment')
 
+    // Create event for payment creation
+    await EventModel.query(trx).insert({
+      action: EventAction.Create,
+      entityType: EventEntityType.Payment,
+      entityId: newPayment.id,
+      userAccountId: user.id,
+    })
+
     if (
       foundPayment.status === PaymentStatus.Failed &&
       foundPayment.error === CirclePaymentErrorCode.three_d_secure_not_supported
@@ -661,14 +669,6 @@ export default class PaymentsService {
       )
       return payment
     }
-
-    // Create event for payment creation
-    await EventModel.query(trx).insert({
-      action: EventAction.Create,
-      entityType: EventEntityType.Payment,
-      entityId: newPayment.id,
-      userAccountId: user.id,
-    })
 
     return newPayment
   }

--- a/apps/web/src/clients/api-client.ts
+++ b/apps/web/src/clients/api-client.ts
@@ -19,7 +19,6 @@ import {
   CreatePayment,
   CreateTransferPayment,
   CreateUserAccountRequest,
-  CreateWalletAddress,
   DEFAULT_LOCALE,
   ExportCollectible,
   ExternalId,
@@ -256,9 +255,9 @@ export class ApiClient {
     return await this.http.post('payments/transfers', { json }).json<Payment>()
   }
 
-  async createWalletAddress(json: CreateWalletAddress) {
+  async createWalletAddress() {
     return await this.http
-      .post('payments/wallets', { json })
+      .post('payments/wallets')
       .json<CircleBlockchainAddress>()
   }
 

--- a/apps/web/src/contexts/payment-context.tsx
+++ b/apps/web/src/contexts/payment-context.tsx
@@ -264,11 +264,6 @@ export function usePaymentProvider({
         1000
       )
 
-      // Throw error if there was a failure code
-      if (!paymentResponse || paymentResponse.status === PaymentStatus.Failed) {
-        throw new Error('Payment failed')
-      }
-
       return paymentResponse
     },
     [release, t]

--- a/apps/web/src/contexts/payment-context.tsx
+++ b/apps/web/src/contexts/payment-context.tsx
@@ -264,6 +264,11 @@ export function usePaymentProvider({
         1000
       )
 
+      // Throw error if there was a failure code
+      if (!paymentResponse || paymentResponse.status === PaymentStatus.Failed) {
+        throw new Error('Payment failed')
+      }
+
       return paymentResponse
     },
     [release, t]

--- a/apps/web/src/pages/api/v1/payments/create-bank-account.ts
+++ b/apps/web/src/pages/api/v1/payments/create-bank-account.ts
@@ -1,6 +1,5 @@
 import { BadRequest } from 'http-errors'
 import { NextApiResponse } from 'next'
-import { v4 as uuid } from 'uuid'
 
 import { ApiClient } from '@/clients/api-client'
 import createHandler, { NextApiRequestApp } from '@/middleware'
@@ -24,7 +23,6 @@ handler.post(
 
     // Create bank account
     const bankAccount = await ApiClient.instance.createBankAccount({
-      idempotencyKey: uuid(),
       accountNumber: body.accountNumber,
       routingNumber: body.routingNumber,
       billingDetails: {

--- a/apps/web/src/pages/api/v1/payments/create-card.ts
+++ b/apps/web/src/pages/api/v1/payments/create-card.ts
@@ -47,7 +47,6 @@ handler.post(
       keyId: body.keyId,
       expirationMonth: Number.parseInt(body.expMonth, 10),
       expirationYear: Number.parseInt('20' + body.expYear, 10),
-      idempotencyKey: uuid(),
       metadata: {
         email,
         ipAddress,

--- a/apps/web/src/pages/api/v1/payments/create-payment.ts
+++ b/apps/web/src/pages/api/v1/payments/create-payment.ts
@@ -35,7 +35,6 @@ handler.post(
 
     // Create payment
     const payment = await ApiClient.instance.createPayment({
-      idempotencyKey: uuid(),
       keyId: body.verificationKeyId,
       encryptedData: body.verificationEncryptedData,
       verification: CirclePaymentVerificationOptions.three_d_secure,

--- a/apps/web/src/pages/checkout/[packSlug]/[method].tsx
+++ b/apps/web/src/pages/checkout/[packSlug]/[method].tsx
@@ -10,7 +10,6 @@ import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import useTranslation from 'next-translate/useTranslation'
 import { useEffect } from 'react'
-import { v4 as uuid } from 'uuid'
 
 import { ApiClient } from '@/clients/api-client'
 import { Analytics } from '@/clients/firebase-analytics'
@@ -195,11 +194,7 @@ export const getServerSideProps: GetServerSideProps<
   let address
   if (params?.method && params.method === CheckoutMethod.crypto) {
     // Get release based on search query
-    address = await ApiClient.instance
-      .createWalletAddress({
-        idempotencyKey: uuid(),
-      })
-      .catch(() => null)
+    address = await ApiClient.instance.createWalletAddress().catch(() => null)
   }
   return {
     props: {

--- a/libs/schemas/src/payments.ts
+++ b/libs/schemas/src/payments.ts
@@ -99,6 +99,11 @@ export enum CirclePaymentErrorCode {
   reference_id_invalid = 'ref_id_invalid',
   unauthorized_transaction = 'unauthorized_transaction',
   wallet_address_mismatch = 'wallet_address_mismatch',
+  three_d_secure_action_expired = 'three_d_secure_action_expired',
+  three_d_secure_failure = 'three_d_secure_failure',
+  three_d_secure_invalid_request = 'three_d_secure_invalid_request',
+  three_d_secure_not_supported = 'three_d_secure_not_supported',
+  three_d_secure_required = 'three_d_secure_required',
 }
 
 export enum CircleCardErrorCode {
@@ -113,11 +118,6 @@ export enum CircleCardErrorCode {
   card_not_honored = 'card_not_honored',
   card_zip_mismatch = 'card_zip_mismatch',
   risk_denied = 'risk_denied',
-  three_d_secure_action_expired = 'three_d_secure_action_expired',
-  three_d_secure_failure = 'three_d_secure_failure',
-  three_d_secure_invalid_request = 'three_d_secure_invalid_request',
-  three_d_secure_not_supported = 'three_d_secure_not_supported',
-  three_d_secure_required = 'three_d_secure_required',
   verification_failed = 'verification_failed',
   verification_fraud_detected = 'verification_fraud_detected',
   verification_not_supported_by_issuer = 'verification_not_supported_by_issuer',
@@ -695,7 +695,7 @@ export const BankAccountIdSchema = Type.Object({
 })
 
 export const CreateCardSchema = Type.Intersect([
-  Type.Omit(CircleCreateCardSchema, ['expMonth', 'expYear']),
+  Type.Omit(CircleCreateCardSchema, ['expMonth', 'expYear', 'idempotencyKey']),
   Type.Object({
     id: Type.Optional(Type.String({ format: 'uuid' })),
     expirationMonth: Type.Number(),
@@ -714,7 +714,7 @@ export const CreateBankAccountResponseSchema = Type.Intersect([
 ])
 
 export const CreateBankAccountSchema = Type.Intersect([
-  CircleCreateBankAccountSchema,
+  Type.Omit(CircleCreateBankAccountSchema, ['idempotencyKey']),
   Type.Object({
     packTemplateId: IdSchema,
     ownerExternalId: Type.String(),
@@ -727,7 +727,7 @@ export const CreatePaymentCardSchema = Type.Union([
 ])
 
 export const CreatePaymentSchema = Type.Intersect([
-  Type.Omit(CircleCreatePaymentSchema, ['source', 'amount']),
+  Type.Omit(CircleCreatePaymentSchema, ['source', 'amount', 'idempotencyKey']),
   Type.Omit(PaymentBaseSchema, ['payerId']),
   Type.Object({
     cardId: Type.String(),
@@ -742,10 +742,6 @@ export const CreateTransferPaymentSchema = Type.Intersect([
     packTemplateId: Type.String({ format: 'uuid' }),
     payerExternalId: Type.String(),
   }),
-])
-
-export const CreateWalletAddressSchema = Type.Intersect([
-  Type.Omit(CircleCreateBlockchainAddressSchema, ['walletId']),
 ])
 
 export const PublicKeySchema = Type.Object({
@@ -833,9 +829,6 @@ export type CreatePayment = Simplify<Static<typeof CreatePaymentSchema>>
 export type CreatePaymentCard = Simplify<Static<typeof CreatePaymentCardSchema>>
 export type CreateTransferPayment = Simplify<
   Static<typeof CreateTransferPaymentSchema>
->
-export type CreateWalletAddress = Simplify<
-  Static<typeof CreateWalletAddressSchema>
 >
 export type Country = Simplify<Static<typeof CountrySchema>>
 export type Countries = Simplify<Static<typeof CountriesSchema>>


### PR DESCRIPTION
### Changes
- Adjust payment flow so that we create the cvv payment after polling for a non-pending status.
  - Circle got back and the initial create payment request will go through if 3DS isn't supported. 
  - We are already polling for a non-pending status in the payments service `createPayment` method. 
  - Now it will check the error code, and create a cvv payment if 3DS isn't supported.
- Moved 3DS errors into `CirclePaymentErrorCode` from card type
  - Circle recommended we create the cvv payment if we get the error code `three_d_secure_not_supported` after the payment moves out of the pending status
    - This is referenced incorrectly as a a card error in [Entity Errors](https://developers.circle.com/docs/entity-errors), but Circle confirmed this is a payment error. 
- Using `uuid()` inside the payment service instead of passing it into the request in web.
  - Circle will error if the same idempotency key is used for a 3DS request and then a cvv request, even if the 3DS request failed. This was the incentive to move into the api, since we need two different uuids. 
  - Updated types accordingly and removed unnecessary types. 

### Testing
Circle has it on their radar to add the ability to test a non-supported 3DS account, and were going to get back on timeline. For now we still can't test the non-supported 3DS, but we got verification of the flow from Circle at least. 