### PR TITLE
Add drop scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ To run eslint for all projects:
 npm run lint
 ```
 
+To initialize the databases:
+
+```bash
+nx drop api &&\
+nx run api:migrate:latest &&\
+nx drop cms &&\
+nx bootstrap cms &&\
+nx import cms
+```
+
 ### Running with docker-compose
 
 The `docker-compose` [configuration](./docker-compose.yml) includes service definitions for the API service,

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -34,6 +34,13 @@ Finally, apply migrations:
 nx run api:migrate:latest
 ```
 
+To initialize the API database:
+
+```bash
+nx drop api &&\
+nx run api:migrate:latest
+```
+
 Per the `.env`, you'll also need to be connected to an Algorand node, whether in development or production.
 
 ### Creating a local Algorand Sandbox account

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,5 @@
 {
   "scripts": {
-    "seed": "./scripts/seed.mjs",
     "drop": "./scripts/drop.mjs"
   }
 }

--- a/apps/api/scripts/drop.mjs
+++ b/apps/api/scripts/drop.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import 'dotenv/config'
+import Knex from 'knex'
+import { readlineAsync } from './utils.mjs'
+
+const dbUrl = new URL(process.env.DATABASE_URL)
+
+const knex = Knex({
+  client: 'pg',
+  connection: `${dbUrl.origin}/postgres`,
+  searchPath: process.env.DB_SEARCH_PATH,
+})
+
+async function main() {
+  console.log(
+    'This operation will drop your API database. Are you sure you want to proceed?'
+  )
+  if ((await readlineAsync('> y/N: ')) !== 'y') {
+    console.log('Operation canceled.')
+    process.exit(0)
+  }
+  const dbName = dbUrl.pathname.substring(1)
+  await knex.raw(`DROP DATABASE IF EXISTS "${dbName}";`)
+  await knex.raw(`CREATE DATABASE "${dbName}";`)
+  console.log('Done!')
+}
+
+main(process.argv)
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+  .finally(() => {
+    return knex.destroy()
+  })

--- a/apps/api/scripts/utils.mjs
+++ b/apps/api/scripts/utils.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import 'dotenv/config'
+
+import { createInterface } from 'readline'
+
+/** Prompt individual CLI user input. */
+export function readlineAsync(prompt) {
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
+    rl.question(prompt, (answer) => {
+      rl.close()
+      resolve(answer)
+    })
+  })
+}

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -30,6 +30,14 @@ npm run seed
 
 > TODO: setup seed Nx executor
 
+To initialize the CMS database:
+
+```bash
+nx drop cms &&\
+nx bootstrap cms &&\
+nx import cms
+```
+
 Once the database is set up, it can be run in conjunction with the other monorepo packages from the root of the repository.
 
 ## Make files publicly viewable

--- a/apps/cms/scripts/drop.mjs
+++ b/apps/cms/scripts/drop.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import 'dotenv/config'
+import Knex from 'knex'
+import { readlineAsync } from './utils.mjs'
+
+const dbUrl = new URL(process.env.DB_CONNECTION_STRING)
+
+const knex = Knex({
+  client: 'pg',
+  connection: `${dbUrl.origin}/postgres`,
+  searchPath: process.env.DB_SEARCH_PATH,
+})
+
+async function main() {
+  console.log(
+    'This operation will drop your CMS database. Are you sure you want to proceed?'
+  )
+  if ((await readlineAsync('> y/N: ')) !== 'y') {
+    console.log('Operation canceled.')
+    process.exit(0)
+  }
+  const dbName = dbUrl.pathname.substring(1)
+  await knex.raw(`DROP DATABASE IF EXISTS "${dbName}";`)
+  await knex.raw(`CREATE DATABASE "${dbName}";`)
+  console.log('Done!')
+}
+
+main(process.argv)
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+  .finally(() => {
+    return knex.destroy()
+  })


### PR DESCRIPTION
Scripts to drop and recreate the databases in API and CMS.

Can be used to re-initialize the whole project like this:

```
nx drop api &&\
nx run api:migrate:latest &&\
nx drop cms &&\
nx bootstrap cms &&\
nx import cms
```