### PR TITLE
Fix for deployment

### DIFF
--- a/apps/cms/snapshot.yml
+++ b/apps/cms/snapshot.yml
@@ -2458,15 +2458,6 @@ fields:
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
     meta:
       collection: nft_templates
       field: preview_image


### PR DESCRIPTION
### Changes
- Removing condition stating the preview image cannot be `null` if the NFT template is published. 
  - GCP was throwing the following error on deployment. It started error'ing when we deployed the changes to prevent null values in the snapshot config. It seems this is causing problems, so removing this conditional. 

#### Error
```
"14:14:32 :rotating_light:Failed to create field "nft_templates.preview_image""
and then
14:14:32 :rotating_light: Undefined binding(s) detected when compiling FIRST. Undefined column(s): [field] query: select "id" from "directus_fields" where "collection" = ? and "field" = ? limit ? "
```