### PR TITLE
Rollback DB transaction when an error is thrown

### DIFF
--- a/apps/api/src/modules/accounts/accounts.service.ts
+++ b/apps/api/src/modules/accounts/accounts.service.ts
@@ -6,11 +6,8 @@ import {
 } from '@algomart/schemas'
 import { UpdateUserAccount } from '@algomart/schemas'
 import { Username } from '@algomart/schemas'
-import got, { Got } from 'got'
 import { Transaction } from 'objection'
-import { v4 } from 'uuid'
 
-import { Configuration } from '@/configuration'
 import AlgorandAdapter from '@/lib/algorand-adapter'
 import { AlgorandAccountModel } from '@/models/algorand-account.model'
 import { AlgorandTransactionModel } from '@/models/algorand-transaction.model'
@@ -31,24 +28,22 @@ export default class AccountsService {
       })
       .orWhere({ externalId: request.externalId })
       .first()
-    // userInvariant(!existing, 'username or externalId already exists', 400)
+    userInvariant(!existing, 'username or externalId already exists', 400)
 
     // 2. generate algorand account (i.e. wallet)
     const result = this.algorand.generateAccount(request.passphrase)
 
     // 3. save account with encrypted mnemonic
     await UserAccountModel.query(trx).insertGraph({
-      username: v4().slice(16),
-      email: `${v4()}@test.local`,
+      username: request.username,
+      email: request.email,
       locale: request.locale,
-      externalId: v4().slice(16),
+      externalId: request.externalId,
       algorandAccount: {
         address: result.address,
         encryptedKey: result.encryptedMnemonic,
       },
     })
-
-    await got.get('https://httpstat.us/401')
 
     // 4. return "public" user account
     const userAccount = await UserAccountModel.query(trx)

--- a/apps/api/src/modules/accounts/accounts.service.ts
+++ b/apps/api/src/modules/accounts/accounts.service.ts
@@ -6,8 +6,11 @@ import {
 } from '@algomart/schemas'
 import { UpdateUserAccount } from '@algomart/schemas'
 import { Username } from '@algomart/schemas'
+import got, { Got } from 'got'
 import { Transaction } from 'objection'
+import { v4 } from 'uuid'
 
+import { Configuration } from '@/configuration'
 import AlgorandAdapter from '@/lib/algorand-adapter'
 import { AlgorandAccountModel } from '@/models/algorand-account.model'
 import { AlgorandTransactionModel } from '@/models/algorand-transaction.model'
@@ -28,22 +31,24 @@ export default class AccountsService {
       })
       .orWhere({ externalId: request.externalId })
       .first()
-    userInvariant(!existing, 'username or externalId already exists', 400)
+    // userInvariant(!existing, 'username or externalId already exists', 400)
 
     // 2. generate algorand account (i.e. wallet)
     const result = this.algorand.generateAccount(request.passphrase)
 
     // 3. save account with encrypted mnemonic
     await UserAccountModel.query(trx).insertGraph({
-      username: request.username,
-      email: request.email,
+      username: v4().slice(16),
+      email: `${v4()}@test.local`,
       locale: request.locale,
-      externalId: request.externalId,
+      externalId: v4().slice(16),
       algorandAccount: {
         address: result.address,
         encryptedKey: result.encryptedMnemonic,
       },
     })
+
+    await got.get('https://httpstat.us/401')
 
     // 4. return "public" user account
     const userAccount = await UserAccountModel.query(trx)

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -12,7 +12,7 @@ export class UserError extends Error {
   }
 }
 
-export function appErrorHandler() {
+export function appErrorHandler(app: FastifyInstance) {
   return async function (
     error: FastifyError,
     request: FastifyRequest,

--- a/apps/api/src/utils/errors.ts
+++ b/apps/api/src/utils/errors.ts
@@ -12,40 +12,15 @@ export class UserError extends Error {
   }
 }
 
-export function appErrorHandler(app: FastifyInstance) {
+export function appErrorHandler() {
   return async function (
     error: FastifyError,
     request: FastifyRequest,
     reply: FastifyReply
   ) {
-    let statusCode = 500
-
     if (error instanceof HTTPError || error instanceof HttpError) {
-      statusCode = error.response.statusCode
-    } else if (error instanceof UserError) {
-      statusCode = error.statusCode
+      reply.status(error.response.statusCode)
     }
-
-    if (statusCode >= 500) {
-      app.log.error(error)
-    } else {
-      app.log.info(error)
-    }
-
-    // Send error response
-    if (error instanceof HTTPError) {
-      // errors from got
-      reply
-        .status(statusCode)
-        .type('application/json')
-        .send(error.response.body)
-    } else {
-      // everything else
-      reply.status(statusCode).send({
-        statusCode,
-        error: error.name,
-        message: error.message,
-      })
-    }
+    throw error
   }
 }


### PR DESCRIPTION
This an alternative fix for the error Ian discovered in #296 

### To test 
1. Backup two commits to **reproduce**  -- The `POST /accounts` endpoint is set up to write a new UserAccount to the DB then make an HTTP call with got that responds 401.
    1.  The POST Accounts should respond with an error
    2.  A DB record should be written to the UserAccounts table, **this is the buggy behavior**
2. Move forward one commit to **fix**
    1.  The POST Accounts should respond with an error. **Regression test:** this error should be functionally equivalent to the error response in step 1.i  (e.g. it should not be a generic 500, it should forward the status code returned by got)
    2.  A DB record should be **not** be written to the UserAccounts table, **this is the correct behavior**

Screen cap: 

https://user-images.githubusercontent.com/3670577/155746672-f00559b5-4eb6-4132-b56b-1c415329c0e6.mp4







