### PR TITLE
Update CMS schema snapshot

### DIFF
--- a/apps/cms/snapshot.yml
+++ b/apps/cms/snapshot.yml
@@ -1,5 +1,5 @@
 version: 1
-directus: 9.4.3
+directus: 9.5.2
 collections:
   - collection: application
     meta:
@@ -22,8 +22,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: application
       schema: public
+      name: application
       comment: null
   - collection: application_countries
     meta:
@@ -46,8 +46,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: application_countries
       schema: public
+      name: application_countries
       comment: null
   - collection: collections
     meta:
@@ -70,8 +70,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: collections
       schema: public
+      name: collections
       comment: null
   - collection: collections_translations
     meta:
@@ -94,8 +94,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: collections_translations
       schema: public
+      name: collections_translations
       comment: null
   - collection: countries
     meta:
@@ -118,8 +118,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: countries
       schema: public
+      name: countries
       comment: null
   - collection: countries_translations
     meta:
@@ -142,8 +142,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: countries_translations
       schema: public
+      name: countries_translations
       comment: null
   - collection: homepage
     meta:
@@ -166,8 +166,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: homepage
       schema: public
+      name: homepage
       comment: null
   - collection: languages
     meta:
@@ -190,8 +190,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: languages
       schema: public
+      name: languages
       comment: null
   - collection: nft_templates
     meta:
@@ -218,8 +218,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: nft_templates
       schema: public
+      name: nft_templates
       comment: null
   - collection: nft_templates_translations
     meta:
@@ -246,8 +246,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: nft_templates_translations
       schema: public
+      name: nft_templates_translations
       comment: null
   - collection: pack_templates
     meta:
@@ -270,8 +270,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: pack_templates
       schema: public
+      name: pack_templates
       comment: null
   - collection: pack_templates_directus_files
     meta:
@@ -294,8 +294,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: pack_templates_directus_files
       schema: public
+      name: pack_templates_directus_files
       comment: null
   - collection: pack_templates_translations
     meta:
@@ -318,8 +318,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: pack_templates_translations
       schema: public
+      name: pack_templates_translations
       comment: null
   - collection: rarities
     meta:
@@ -346,8 +346,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: rarities
       schema: public
+      name: rarities
       comment: null
   - collection: rarities_translations
     meta:
@@ -370,8 +370,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: rarities_translations
       schema: public
+      name: rarities_translations
       comment: null
   - collection: sets
     meta:
@@ -394,8 +394,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: sets
       schema: public
+      name: sets
       comment: null
   - collection: sets_translations
     meta:
@@ -418,8 +418,8 @@ collections:
       group: null
       collapse: open
     schema:
-      name: sets_translations
       schema: public
+      name: sets_translations
       comment: null
 fields:
   - collection: application
@@ -428,19 +428,19 @@ fields:
     schema:
       name: id
       table: application
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -468,19 +468,19 @@ fields:
     schema:
       name: currency
       table: application
+      schema: public
       data_type: character varying
-      default_value: USD
+      is_nullable: false
       generation_expression: null
+      default_value: USD
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -838,19 +838,19 @@ fields:
     schema:
       name: id
       table: application_countries
+      schema: public
       data_type: integer
-      default_value: nextval('application_countries_id_seq'::regclass)
+      is_nullable: false
       generation_expression: null
+      default_value: nextval('application_countries_id_seq'::regclass)
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: true
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -877,19 +877,19 @@ fields:
     schema:
       name: application_id
       table: application_countries
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: application
       foreign_key_column: id
@@ -916,19 +916,19 @@ fields:
     schema:
       name: countries_code
       table: application_countries
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: countries
       foreign_key_column: code
@@ -955,19 +955,19 @@ fields:
     schema:
       name: id
       table: collections
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -982,7 +982,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 1
       width: full
       translations: null
       note: null
@@ -995,19 +995,19 @@ fields:
     schema:
       name: status
       table: collections
+      schema: public
       data_type: character varying
-      default_value: draft
+      is_nullable: false
       generation_expression: null
+      default_value: draft
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1036,7 +1036,7 @@ fields:
             value: archived
       readonly: false
       hidden: false
-      sort: null
+      sort: 8
       width: half
       translations: null
       note: null
@@ -1057,19 +1057,19 @@ fields:
     schema:
       name: sort
       table: collections
+      schema: public
       data_type: integer
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1083,8 +1083,8 @@ fields:
       display_options: null
       readonly: false
       hidden: true
-      sort: null
-      width: half
+      sort: 2
+      width: fill
       translations: null
       note: null
       conditions: null
@@ -1096,19 +1096,19 @@ fields:
     schema:
       name: user_created
       table: collections
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -1124,7 +1124,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 3
       width: half
       translations: null
       note: null
@@ -1137,19 +1137,19 @@ fields:
     schema:
       name: date_created
       table: collections
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1165,7 +1165,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 4
       width: half
       translations: null
       note: null
@@ -1178,19 +1178,19 @@ fields:
     schema:
       name: user_updated
       table: collections
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -1206,7 +1206,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 5
       width: half
       translations: null
       note: null
@@ -1219,19 +1219,19 @@ fields:
     schema:
       name: date_updated
       table: collections
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1247,7 +1247,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 6
       width: half
       translations: null
       note: null
@@ -1260,19 +1260,19 @@ fields:
     schema:
       name: slug
       table: collections
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1288,7 +1288,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 7
       width: half
       translations: null
       note: null
@@ -1309,19 +1309,19 @@ fields:
     schema:
       name: collection_image
       table: collections
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
@@ -1335,7 +1335,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 9
       width: full
       translations: null
       note: null
@@ -1348,19 +1348,19 @@ fields:
     schema:
       name: reward_image
       table: collections
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
@@ -1374,7 +1374,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 10
       width: full
       translations: null
       note: >-
@@ -1389,19 +1389,19 @@ fields:
     schema:
       name: id
       table: collections_translations
+      schema: public
       data_type: integer
-      default_value: nextval('collections_translations_id_seq'::regclass)
+      is_nullable: false
       generation_expression: null
+      default_value: nextval('collections_translations_id_seq'::regclass)
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: true
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1428,19 +1428,19 @@ fields:
     schema:
       name: collections_id
       table: collections_translations
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: collections
       foreign_key_column: id
@@ -1467,19 +1467,19 @@ fields:
     schema:
       name: languages_code
       table: collections_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
@@ -1506,19 +1506,19 @@ fields:
     schema:
       name: name
       table: collections_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1538,7 +1538,7 @@ fields:
       translations: null
       note: null
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: collections_translations
     field: description
@@ -1546,19 +1546,19 @@ fields:
     schema:
       name: description
       table: collections_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1586,19 +1586,19 @@ fields:
     schema:
       name: metadata
       table: collections_translations
+      schema: public
       data_type: json
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1639,19 +1639,19 @@ fields:
     schema:
       name: reward_prompt
       table: collections_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1681,19 +1681,19 @@ fields:
     schema:
       name: reward_complete
       table: collections_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1723,19 +1723,19 @@ fields:
     schema:
       name: code
       table: countries
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1762,19 +1762,19 @@ fields:
     schema:
       name: id
       table: countries_translations
+      schema: public
       data_type: integer
-      default_value: nextval('countries_translations_id_seq'::regclass)
+      is_nullable: false
       generation_expression: null
+      default_value: nextval('countries_translations_id_seq'::regclass)
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: true
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1801,19 +1801,19 @@ fields:
     schema:
       name: countries_code
       table: countries_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: countries
       foreign_key_column: code
@@ -1840,19 +1840,19 @@ fields:
     schema:
       name: languages_code
       table: countries_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
@@ -1879,19 +1879,19 @@ fields:
     schema:
       name: title
       table: countries_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1911,7 +1911,7 @@ fields:
       translations: null
       note: null
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: homepage
     field: id
@@ -1919,19 +1919,19 @@ fields:
     schema:
       name: id
       table: homepage
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -1959,19 +1959,19 @@ fields:
     schema:
       name: featured_pack
       table: homepage
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: pack_templates
       foreign_key_column: id
@@ -1981,7 +1981,7 @@ fields:
       special: null
       interface: select-dropdown-m2o
       options:
-        template: '{{slug}} {{type}}'
+        template: "{{slug}}\_ {{type}}\_{{translations}}"
       display: related-values
       display_options:
         template: '{{slug}} {{type}}'
@@ -2000,19 +2000,19 @@ fields:
     schema:
       name: code
       table: languages
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2040,19 +2040,19 @@ fields:
     schema:
       name: name
       table: languages
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2072,7 +2072,7 @@ fields:
       translations: null
       note: null
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: nft_templates
     field: id
@@ -2080,19 +2080,19 @@ fields:
     schema:
       name: id
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2107,7 +2107,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 1
       width: full
       translations: null
       note: null
@@ -2120,19 +2120,19 @@ fields:
     schema:
       name: status
       table: nft_templates
+      schema: public
       data_type: character varying
-      default_value: draft
+      is_nullable: false
       generation_expression: null
+      default_value: draft
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2161,7 +2161,7 @@ fields:
             value: archived
       readonly: false
       hidden: false
-      sort: null
+      sort: 7
       width: half
       translations: null
       note: null
@@ -2174,7 +2174,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: nft_templates
     field: user_created
@@ -2182,19 +2182,19 @@ fields:
     schema:
       name: user_created
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -2210,7 +2210,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 2
       width: half
       translations: null
       note: null
@@ -2223,19 +2223,19 @@ fields:
     schema:
       name: date_created
       table: nft_templates
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2251,7 +2251,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 3
       width: half
       translations: null
       note: null
@@ -2264,19 +2264,19 @@ fields:
     schema:
       name: user_updated
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -2292,7 +2292,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 4
       width: half
       translations: null
       note: null
@@ -2305,19 +2305,19 @@ fields:
     schema:
       name: date_updated
       table: nft_templates
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2333,7 +2333,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 5
       width: half
       translations: null
       note: null
@@ -2346,19 +2346,19 @@ fields:
     schema:
       name: total_editions
       table: nft_templates
+      schema: public
       data_type: integer
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2373,7 +2373,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 8
       width: half
       translations: null
       note: null
@@ -2386,7 +2386,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: nft_templates
     field: unique_code
@@ -2394,19 +2394,19 @@ fields:
     schema:
       name: unique_code
       table: nft_templates
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 8
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2421,7 +2421,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 9
       width: half
       translations: null
       note: null
@@ -2434,7 +2434,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: nft_templates
     field: preview_image
@@ -2442,19 +2442,19 @@ fields:
     schema:
       name: preview_image
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
@@ -2468,7 +2468,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 14
       width: full
       translations: null
       note: null
@@ -2484,7 +2484,7 @@ fields:
           required: false
           options:
             crop: false
-      required: false
+      required: true
       group: null
   - collection: nft_templates
     field: preview_video
@@ -2492,19 +2492,19 @@ fields:
     schema:
       name: preview_video
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
@@ -2518,7 +2518,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 15
       width: full
       translations: null
       note: null
@@ -2531,19 +2531,19 @@ fields:
     schema:
       name: preview_audio
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
@@ -2557,7 +2557,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 16
       width: full
       translations: null
       note: null
@@ -2570,19 +2570,19 @@ fields:
     schema:
       name: asset_file
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
@@ -2596,7 +2596,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 17
       width: full
       translations: null
       note: null
@@ -2609,19 +2609,19 @@ fields:
     schema:
       name: pack_template
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: pack_templates
       foreign_key_column: id
@@ -2633,16 +2633,26 @@ fields:
       interface: select-dropdown-m2o
       options:
         template: '{{slug}}'
+        filter:
+          _and:
+            - status:
+                _ncontains: published
       display: related-values
       display_options:
         template: '{{slug}}'
       readonly: false
       hidden: false
-      sort: null
-      width: half
+      sort: 11
+      width: full
       translations: null
       note: null
       conditions:
+        - name: Required if status is Published
+          rule:
+            _and:
+              - status:
+                  _contains: published
+          required: true
         - name: No editing after publish
           rule:
             _and:
@@ -2659,19 +2669,19 @@ fields:
     schema:
       name: rarity
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: rarities
       foreign_key_column: id
@@ -2681,13 +2691,14 @@ fields:
       special: null
       interface: select-dropdown-m2o
       options:
-        template: '{{code}}'
+        template: "{{color}}\_{{code}}\_{{translations}}"
+        filter: null
       display: related-values
       display_options:
-        template: '{{code}}'
+        template: "{{color}}\_{{code}}\_{{translations}}"
       readonly: false
       hidden: false
-      sort: null
+      sort: 10
       width: half
       translations: null
       note: null
@@ -2708,19 +2719,19 @@ fields:
     schema:
       name: set
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: sets
       foreign_key_column: id
@@ -2737,7 +2748,7 @@ fields:
         template: '{{slug}}'
       readonly: false
       hidden: false
-      sort: null
+      sort: 12
       width: half
       translations: null
       note: null
@@ -2758,19 +2769,19 @@ fields:
     schema:
       name: collection
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: collections
       foreign_key_column: id
@@ -2787,7 +2798,7 @@ fields:
         template: '{{slug}}'
       readonly: false
       hidden: false
-      sort: null
+      sort: 13
       width: half
       translations: null
       note: null
@@ -2808,19 +2819,19 @@ fields:
     schema:
       name: homepage
       table: nft_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: homepage
       foreign_key_column: id
@@ -2834,7 +2845,7 @@ fields:
       display_options: null
       readonly: false
       hidden: true
-      sort: null
+      sort: 6
       width: full
       translations: null
       note: null
@@ -2847,19 +2858,19 @@ fields:
     schema:
       name: id
       table: nft_templates_translations
+      schema: public
       data_type: integer
-      default_value: nextval('nft_templates_translations_id_seq'::regclass)
+      is_nullable: false
       generation_expression: null
+      default_value: nextval('nft_templates_translations_id_seq'::regclass)
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: true
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2886,19 +2897,19 @@ fields:
     schema:
       name: nft_templates_id
       table: nft_templates_translations
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: nft_templates
       foreign_key_column: id
@@ -2925,19 +2936,19 @@ fields:
     schema:
       name: languages_code
       table: nft_templates_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
@@ -2964,19 +2975,19 @@ fields:
     schema:
       name: title
       table: nft_templates_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -2996,7 +3007,7 @@ fields:
       translations: null
       note: null
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: nft_templates_translations
     field: subtitle
@@ -3004,19 +3015,19 @@ fields:
     schema:
       name: subtitle
       table: nft_templates_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3044,19 +3055,19 @@ fields:
     schema:
       name: body
       table: nft_templates_translations
+      schema: public
       data_type: text
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3083,19 +3094,19 @@ fields:
     schema:
       name: id
       table: pack_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3110,7 +3121,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 1
       width: full
       translations: null
       note: null
@@ -3123,19 +3134,19 @@ fields:
     schema:
       name: status
       table: pack_templates
+      schema: public
       data_type: character varying
-      default_value: draft
+      is_nullable: false
       generation_expression: null
+      default_value: draft
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3164,10 +3175,12 @@ fields:
             value: archived
       readonly: false
       hidden: false
-      sort: null
+      sort: 8
       width: half
       translations: null
-      note: null
+      note: >-
+        Most fields of this Pack Template cannot be edited once it's been
+        published.
       conditions:
         - name: No editing after publish
           rule:
@@ -3177,7 +3190,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: pack_templates
     field: sort
@@ -3185,19 +3198,19 @@ fields:
     schema:
       name: sort
       table: pack_templates
+      schema: public
       data_type: integer
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3211,7 +3224,7 @@ fields:
       display_options: null
       readonly: false
       hidden: true
-      sort: null
+      sort: 2
       width: half
       translations: null
       note: null
@@ -3224,19 +3237,19 @@ fields:
     schema:
       name: user_created
       table: pack_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -3252,7 +3265,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 4
       width: half
       translations: null
       note: null
@@ -3265,19 +3278,19 @@ fields:
     schema:
       name: date_created
       table: pack_templates
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3293,7 +3306,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 5
       width: half
       translations: null
       note: null
@@ -3306,19 +3319,19 @@ fields:
     schema:
       name: user_updated
       table: pack_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -3334,7 +3347,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 6
       width: half
       translations: null
       note: null
@@ -3347,19 +3360,19 @@ fields:
     schema:
       name: date_updated
       table: pack_templates
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3375,7 +3388,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 7
       width: half
       translations: null
       note: null
@@ -3388,19 +3401,19 @@ fields:
     schema:
       name: slug
       table: pack_templates
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3416,10 +3429,10 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 9
       width: half
       translations: null
-      note: null
+      note: Used as part of the URL for this pack.
       conditions:
         - name: No editing after publish
           rule:
@@ -3429,7 +3442,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: pack_templates
     field: type
@@ -3437,19 +3450,19 @@ fields:
     schema:
       name: type
       table: pack_templates
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3472,10 +3485,13 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 10
       width: half
       translations: null
-      note: null
+      note: >-
+        Free: anyone can acquire the pack. Redeem: a unique redemption code is
+        required to acquire the pack. Purchase: a fixed price must be paid.
+        Auction: highest bidder buys the pack and only one pack is available.
       conditions:
         - name: No editing after publish
           rule:
@@ -3485,7 +3501,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: pack_templates
     field: price
@@ -3493,19 +3509,19 @@ fields:
     schema:
       name: price
       table: pack_templates
+      schema: public
       data_type: integer
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3521,13 +3537,21 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 11
       width: half
       translations: null
       note: >-
         Price in application currency. For auctions, this is the initial asking
         price.
       conditions:
+        - name: Required if Purchase or Auction
+          rule:
+            _and:
+              - type:
+                  _in:
+                    - purchase
+                    - auction
+          required: true
         - name: No editing after publish
           rule:
             _and:
@@ -3544,19 +3568,19 @@ fields:
     schema:
       name: released_at
       table: pack_templates
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3570,10 +3594,10 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 12
       width: half
       translations: null
-      note: null
+      note: When will packs be available for acquisition?
       conditions:
         - name: No editing after publish
           rule:
@@ -3583,7 +3607,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: pack_templates
     field: auction_until
@@ -3591,19 +3615,19 @@ fields:
     schema:
       name: auction_until
       table: pack_templates
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3617,11 +3641,17 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 13
       width: half
       translations: null
       note: Auction this pack until this date and time.
       conditions:
+        - name: Required if Auction
+          rule:
+            _and:
+              - type:
+                  _contains: auction
+          required: true
         - name: No editing after publish
           rule:
             _and:
@@ -3638,19 +3668,19 @@ fields:
     schema:
       name: show_nfts
       table: pack_templates
+      schema: public
       data_type: boolean
-      default_value: false
+      is_nullable: false
       generation_expression: null
+      default_value: false
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3667,7 +3697,7 @@ fields:
         labelOff: Hiding NFTs
       readonly: false
       hidden: false
-      sort: null
+      sort: 14
       width: half
       translations:
         - language: en-US
@@ -3692,19 +3722,19 @@ fields:
     schema:
       name: nft_order
       table: pack_templates
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: random
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3723,7 +3753,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 15
       width: half
       translations:
         - language: en-US
@@ -3738,7 +3768,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: pack_templates
     field: nft_distribution
@@ -3746,19 +3776,19 @@ fields:
     schema:
       name: nft_distribution
       table: pack_templates
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: random
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3777,7 +3807,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 16
       width: half
       translations:
         - language: en-US
@@ -3792,7 +3822,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: pack_templates
     field: nfts_per_pack
@@ -3800,19 +3830,19 @@ fields:
     schema:
       name: nfts_per_pack
       table: pack_templates
+      schema: public
       data_type: integer
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: 1
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3827,7 +3857,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 17
       width: half
       translations:
         - language: en-US
@@ -3842,7 +3872,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-      required: false
+      required: true
       group: null
   - collection: pack_templates
     field: pack_image
@@ -3850,19 +3880,19 @@ fields:
     schema:
       name: pack_image
       table: pack_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
@@ -3876,12 +3906,12 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 21
       width: full
       translations: null
       note: Primary image shown for this pack.
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: pack_templates
     field: allow_bid_expiration
@@ -3889,19 +3919,19 @@ fields:
     schema:
       name: allow_bid_expiration
       table: pack_templates
+      schema: public
       data_type: boolean
-      default_value: false
+      is_nullable: false
       generation_expression: null
+      default_value: false
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -3918,7 +3948,7 @@ fields:
         labelOff: Bids do not expire
       readonly: false
       hidden: false
-      sort: null
+      sort: 18
       width: half
       translations:
         - language: en-US
@@ -3944,19 +3974,19 @@ fields:
     schema:
       name: homepage
       table: pack_templates
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: homepage
       foreign_key_column: id
@@ -3970,8 +4000,8 @@ fields:
       display_options: null
       readonly: false
       hidden: true
-      sort: null
-      width: full
+      sort: 3
+      width: half
       translations: null
       note: null
       conditions: null
@@ -3983,19 +4013,19 @@ fields:
     schema:
       name: one_pack_per_customer
       table: pack_templates
+      schema: public
       data_type: boolean
-      default_value: false
+      is_nullable: false
       generation_expression: null
+      default_value: false
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4012,7 +4042,7 @@ fields:
         labelOff: Customers can buy multiple versions of this pack
       readonly: false
       hidden: false
-      sort: null
+      sort: 19
       width: half
       translations:
         - language: en-US
@@ -4038,19 +4068,19 @@ fields:
     schema:
       name: id
       table: pack_templates_directus_files
+      schema: public
       data_type: integer
-      default_value: nextval('pack_templates_directus_files_id_seq'::regclass)
+      is_nullable: false
       generation_expression: null
+      default_value: nextval('pack_templates_directus_files_id_seq'::regclass)
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: true
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4077,19 +4107,19 @@ fields:
     schema:
       name: directus_files_id
       table: pack_templates_directus_files
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
@@ -4116,19 +4146,19 @@ fields:
     schema:
       name: pack_templates_id
       table: pack_templates_directus_files
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: pack_templates
       foreign_key_column: id
@@ -4155,19 +4185,19 @@ fields:
     schema:
       name: sort
       table: pack_templates_directus_files
+      schema: public
       data_type: integer
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4194,19 +4224,19 @@ fields:
     schema:
       name: id
       table: pack_templates_translations
+      schema: public
       data_type: integer
-      default_value: nextval('pack_templates_translations_id_seq'::regclass)
+      is_nullable: false
       generation_expression: null
+      default_value: nextval('pack_templates_translations_id_seq'::regclass)
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: true
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4233,19 +4263,19 @@ fields:
     schema:
       name: pack_templates_id
       table: pack_templates_translations
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: pack_templates
       foreign_key_column: id
@@ -4272,19 +4302,19 @@ fields:
     schema:
       name: languages_code
       table: pack_templates_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
@@ -4311,19 +4341,19 @@ fields:
     schema:
       name: title
       table: pack_templates_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4343,7 +4373,7 @@ fields:
       translations: null
       note: null
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: pack_templates_translations
     field: subtitle
@@ -4351,19 +4381,19 @@ fields:
     schema:
       name: subtitle
       table: pack_templates_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4391,19 +4421,19 @@ fields:
     schema:
       name: body
       table: pack_templates_translations
+      schema: public
       data_type: text
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4430,19 +4460,19 @@ fields:
     schema:
       name: id
       table: rarities
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4457,7 +4487,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 1
       width: full
       translations: null
       note: null
@@ -4470,19 +4500,19 @@ fields:
     schema:
       name: user_created
       table: rarities
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -4498,7 +4528,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 2
       width: half
       translations: null
       note: null
@@ -4511,19 +4541,19 @@ fields:
     schema:
       name: date_created
       table: rarities
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4539,7 +4569,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 3
       width: half
       translations: null
       note: null
@@ -4552,19 +4582,19 @@ fields:
     schema:
       name: user_updated
       table: rarities
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -4580,7 +4610,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 4
       width: half
       translations: null
       note: null
@@ -4593,19 +4623,19 @@ fields:
     schema:
       name: date_updated
       table: rarities
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4621,7 +4651,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 5
       width: half
       translations: null
       note: null
@@ -4634,19 +4664,19 @@ fields:
     schema:
       name: code
       table: rarities
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 2
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4661,12 +4691,12 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 7
       width: half
       translations: null
-      note: null
+      note: Unique two-character code, e.g. LE, CC, EP, RA.
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: rarities
     field: color
@@ -4674,19 +4704,19 @@ fields:
     schema:
       name: color
       table: rarities
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4700,12 +4730,12 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 6
       width: half
       translations: null
-      note: null
+      note: Color shown in the UI for any NFT with this rarity set.
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: rarities_translations
     field: id
@@ -4713,19 +4743,19 @@ fields:
     schema:
       name: id
       table: rarities_translations
+      schema: public
       data_type: integer
-      default_value: nextval('rarities_translations_id_seq'::regclass)
+      is_nullable: false
       generation_expression: null
+      default_value: nextval('rarities_translations_id_seq'::regclass)
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: true
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4752,19 +4782,19 @@ fields:
     schema:
       name: rarities_id
       table: rarities_translations
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: rarities
       foreign_key_column: id
@@ -4791,19 +4821,19 @@ fields:
     schema:
       name: languages_code
       table: rarities_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
@@ -4830,19 +4860,19 @@ fields:
     schema:
       name: name
       table: rarities_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4862,7 +4892,7 @@ fields:
       translations: null
       note: null
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: sets
     field: id
@@ -4870,19 +4900,19 @@ fields:
     schema:
       name: id
       table: sets
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4897,7 +4927,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 1
       width: full
       translations: null
       note: null
@@ -4910,19 +4940,19 @@ fields:
     schema:
       name: status
       table: sets
+      schema: public
       data_type: character varying
-      default_value: draft
+      is_nullable: false
       generation_expression: null
+      default_value: draft
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4951,7 +4981,7 @@ fields:
             value: archived
       readonly: false
       hidden: false
-      sort: null
+      sort: 8
       width: half
       translations: null
       note: null
@@ -4972,19 +5002,19 @@ fields:
     schema:
       name: sort
       table: sets
+      schema: public
       data_type: integer
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -4998,8 +5028,8 @@ fields:
       display_options: null
       readonly: false
       hidden: true
-      sort: null
-      width: half
+      sort: 2
+      width: full
       translations: null
       note: null
       conditions: null
@@ -5011,19 +5041,19 @@ fields:
     schema:
       name: user_created
       table: sets
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -5039,7 +5069,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 3
       width: half
       translations: null
       note: null
@@ -5052,19 +5082,19 @@ fields:
     schema:
       name: date_created
       table: sets
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -5080,7 +5110,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 4
       width: half
       translations: null
       note: null
@@ -5093,19 +5123,19 @@ fields:
     schema:
       name: user_updated
       table: sets
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
@@ -5121,7 +5151,7 @@ fields:
       display_options: null
       readonly: true
       hidden: true
-      sort: null
+      sort: 5
       width: half
       translations: null
       note: null
@@ -5134,19 +5164,19 @@ fields:
     schema:
       name: date_updated
       table: sets
+      schema: public
       data_type: timestamp with time zone
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -5162,7 +5192,7 @@ fields:
         relative: true
       readonly: true
       hidden: true
-      sort: null
+      sort: 6
       width: half
       translations: null
       note: null
@@ -5175,19 +5205,19 @@ fields:
     schema:
       name: slug
       table: sets
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -5203,7 +5233,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 7
       width: half
       translations: null
       note: null
@@ -5224,19 +5254,19 @@ fields:
     schema:
       name: collection
       table: sets
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: false
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: collections
       foreign_key_column: id
@@ -5253,8 +5283,8 @@ fields:
         template: '{{slug}}'
       readonly: false
       hidden: false
-      sort: null
-      width: half
+      sort: 9
+      width: fill
       translations: null
       note: null
       conditions:
@@ -5274,19 +5304,19 @@ fields:
     schema:
       name: id
       table: sets_translations
+      schema: public
       data_type: integer
-      default_value: nextval('sets_translations_id_seq'::regclass)
+      is_nullable: false
       generation_expression: null
+      default_value: nextval('sets_translations_id_seq'::regclass)
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: 32
       numeric_scale: 0
-      is_generated: false
-      is_nullable: false
       is_unique: true
       is_primary_key: true
       has_auto_increment: true
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -5313,19 +5343,19 @@ fields:
     schema:
       name: sets_id
       table: sets_translations
+      schema: public
       data_type: uuid
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: null
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: sets
       foreign_key_column: id
@@ -5352,19 +5382,19 @@ fields:
     schema:
       name: languages_code
       table: sets_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: true
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
@@ -5391,19 +5421,19 @@ fields:
     schema:
       name: name
       table: sets_translations
+      schema: public
       data_type: character varying
-      default_value: null
+      is_nullable: true
       generation_expression: null
+      default_value: null
+      is_generated: false
       max_length: 255
+      comment: null
       numeric_precision: null
       numeric_scale: null
-      is_generated: false
-      is_nullable: false
       is_unique: false
       is_primary_key: false
       has_auto_increment: false
-      comment: null
-      schema: public
       foreign_key_schema: null
       foreign_key_table: null
       foreign_key_column: null
@@ -5423,143 +5453,7 @@ fields:
       translations: null
       note: null
       conditions: null
-      required: false
-      group: null
-  - collection: application
-    field: countries
-    type: alias
-    schema: null
-    meta:
-      collection: application
-      field: countries
-      special:
-        - m2m
-      interface: list-m2m
-      options: null
-      display: null
-      display_options: null
-      readonly: false
-      hidden: false
-      sort: null
-      width: full
-      translations: null
-      note: null
-      conditions: null
-      required: false
-      group: null
-  - collection: collections
-    field: translations
-    type: alias
-    schema: null
-    meta:
-      collection: collections
-      field: translations
-      special:
-        - translations
-      interface: translations
-      options:
-        languageTemplate: '{{name}}'
-        translationsTemplate: '{{name}}'
-      display: null
-      display_options: null
-      readonly: false
-      hidden: false
-      sort: null
-      width: full
-      translations: null
-      note: null
-      conditions: null
-      required: false
-      group: null
-  - collection: collections
-    field: sets
-    type: alias
-    schema: null
-    meta:
-      collection: collections
-      field: sets
-      special:
-        - o2m
-      interface: list-o2m
-      options:
-        enableCreate: false
-        enableSelect: true
-        template: '{{slug}}'
-      display: null
-      display_options: null
-      readonly: false
-      hidden: false
-      sort: null
-      width: full
-      translations: null
-      note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
-      required: false
-      group: null
-  - collection: collections
-    field: nft_templates
-    type: alias
-    schema: null
-    meta:
-      collection: collections
-      field: nft_templates
-      special:
-        - o2m
-      interface: list-o2m
-      options:
-        enableCreate: false
-        enableSelect: true
-        template: '{{unique_code}}'
-      display: null
-      display_options: null
-      readonly: false
-      hidden: false
-      sort: null
-      width: full
-      translations:
-        - language: en-US
-          translation: NFT Templates
-      note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
-      required: false
-      group: null
-  - collection: countries
-    field: translations
-    type: alias
-    schema: null
-    meta:
-      collection: countries
-      field: translations
-      special:
-        - translations
-      interface: translations
-      options: null
-      display: null
-      display_options: null
-      readonly: false
-      hidden: false
-      sort: null
-      width: full
-      translations: null
-      note: null
-      conditions: null
-      required: false
+      required: true
       group: null
   - collection: homepage
     field: upcoming_packs
@@ -5609,94 +5503,87 @@ fields:
       conditions: null
       required: false
       group: null
-  - collection: nft_templates
+  - collection: collections
     field: translations
     type: alias
     schema: null
     meta:
-      collection: nft_templates
+      collection: collections
       field: translations
       special:
         - translations
       interface: translations
       options:
         languageTemplate: '{{name}}'
-        translationsTemplate: '{{title}}'
-      display: null
-      display_options: null
+        translationsTemplate: '{{name}}'
+        languageField: code
+      display: translations
+      display_options:
+        template: '{{name}}'
+        languageField: code
+        defaultLanguage: en-US
+        userLanguage: true
       readonly: false
       hidden: false
-      sort: null
+      sort: 13
       width: full
       translations: null
       note: null
       conditions: null
       required: false
       group: null
-  - collection: pack_templates
-    field: translations
+  - collection: collections
+    field: sets
     type: alias
     schema: null
     meta:
-      collection: pack_templates
-      field: translations
+      collection: collections
+      field: sets
       special:
-        - translations
-      interface: translations
+        - o2m
+      interface: list-o2m
       options:
-        languageTemplate: '{{name}}'
-        translationsTemplate: '{{title}}'
+        enableCreate: false
+        enableSelect: true
+        template: '{{slug}}'
       display: null
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 11
       width: full
       translations: null
       note: null
-      conditions: null
+      conditions:
+        - name: No editing after publish
+          rule:
+            _and:
+              - status:
+                  _eq: published
+              - id:
+                  _nnull: true
+          readonly: true
       required: false
       group: null
-  - collection: pack_templates
-    field: additional_images
-    type: alias
-    schema: null
-    meta:
-      collection: pack_templates
-      field: additional_images
-      special:
-        - files
-      interface: list-m2m
-      options: null
-      display: null
-      display_options: null
-      readonly: false
-      hidden: false
-      sort: null
-      width: full
-      translations: null
-      note: Optional, additional preview images & files shown on the pack page.
-      conditions: null
-      required: false
-      group: null
-  - collection: pack_templates
+  - collection: collections
     field: nft_templates
     type: alias
     schema: null
     meta:
-      collection: pack_templates
+      collection: collections
       field: nft_templates
       special:
         - o2m
       interface: list-o2m
       options:
         enableCreate: false
+        enableSelect: true
         template: '{{unique_code}}'
       display: null
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 12
       width: full
       translations:
         - language: en-US
@@ -5713,6 +5600,107 @@ fields:
           readonly: true
       required: false
       group: null
+  - collection: countries
+    field: translations
+    type: alias
+    schema: null
+    meta:
+      collection: countries
+      field: translations
+      special:
+        - translations
+      interface: translations
+      options:
+        languageField: code
+      display: translations
+      display_options:
+        template: '{{title}}'
+        languageField: code
+        defaultLanguage: en-US
+        userLanguage: true
+      readonly: false
+      hidden: false
+      sort: null
+      width: full
+      translations: null
+      note: null
+      conditions: null
+      required: false
+      group: null
+  - collection: application
+    field: countries
+    type: alias
+    schema: null
+    meta:
+      collection: application
+      field: countries
+      special:
+        - m2m
+      interface: list-m2m
+      options: null
+      display: related-values
+      display_options:
+        template: '{{countries_code.code}}'
+      readonly: false
+      hidden: false
+      sort: null
+      width: full
+      translations: null
+      note: null
+      conditions: null
+      required: false
+      group: null
+  - collection: nft_templates
+    field: translations
+    type: alias
+    schema: null
+    meta:
+      collection: nft_templates
+      field: translations
+      special:
+        - translations
+      interface: translations
+      options:
+        languageTemplate: '{{name}}'
+        translationsTemplate: '{{title}}'
+        languageField: code
+      display: translations
+      display_options:
+        template: '{{title}}'
+        languageField: code
+        defaultLanguage: en-US
+        userLanguage: true
+      readonly: false
+      hidden: false
+      sort: 18
+      width: full
+      translations: null
+      note: null
+      conditions: null
+      required: true
+      group: null
+  - collection: pack_templates
+    field: additional_images
+    type: alias
+    schema: null
+    meta:
+      collection: pack_templates
+      field: additional_images
+      special:
+        - files
+      interface: list-m2m
+      options: null
+      display: null
+      display_options: null
+      readonly: false
+      hidden: false
+      sort: 22
+      width: full
+      translations: null
+      note: Optional, additional preview images & files shown on the pack page.
+      conditions: null
+      required: false
+      group: null
   - collection: rarities
     field: translations
     type: alias
@@ -5726,40 +5714,50 @@ fields:
       options:
         languageTemplate: '{{name}}'
         translationsTemplate: '{{name}}'
-      display: null
-      display_options: null
+        languageField: code
+      display: translations
+      display_options:
+        template: '{{name}}'
+        languageField: code
+        userLanguage: true
+        defaultLanguage: en-US
       readonly: false
       hidden: false
-      sort: null
+      sort: 8
       width: full
       translations: null
       note: null
       conditions: null
-      required: false
+      required: true
       group: null
-  - collection: sets
+  - collection: pack_templates
     field: translations
     type: alias
     schema: null
     meta:
-      collection: sets
+      collection: pack_templates
       field: translations
       special:
         - translations
       interface: translations
       options:
         languageTemplate: '{{name}}'
-        translationsTemplate: '{{name}}'
-      display: null
-      display_options: null
+        translationsTemplate: '{{title}}'
+        languageField: code
+      display: translations
+      display_options:
+        template: '{{title}}'
+        languageField: code
+        defaultLanguage: en-US
+        userLanguage: true
       readonly: false
       hidden: false
-      sort: null
+      sort: 23
       width: full
       translations: null
       note: null
       conditions: null
-      required: false
+      required: true
       group: null
   - collection: sets
     field: nft_templates
@@ -5779,7 +5777,7 @@ fields:
       display_options: null
       readonly: false
       hidden: false
-      sort: null
+      sort: 10
       width: full
       translations:
         - language: en-US
@@ -5796,39 +5794,91 @@ fields:
           readonly: true
       required: false
       group: null
-relations:
-  - collection: application_countries
-    field: countries_code
-    related_collection: countries
-    schema:
-      table: application_countries
-      column: countries_code
-      foreign_key_table: countries
-      foreign_key_column: code
-      foreign_key_schema: public
-      constraint_name: application_countries_countries_code_foreign
-      on_update: NO ACTION
-      on_delete: SET NULL
+  - collection: sets
+    field: translations
+    type: alias
+    schema: null
     meta:
-      many_collection: application_countries
-      many_field: countries_code
-      one_collection: countries
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: application_id
-      sort_field: null
-      one_deselect_action: nullify
+      collection: sets
+      field: translations
+      special:
+        - translations
+      interface: translations
+      options:
+        languageTemplate: '{{name}}'
+        translationsTemplate: '{{name}}'
+        languageField: code
+      display: translations
+      display_options:
+        template: '{{name}}'
+        languageField: code
+        defaultLanguage: en-US
+        userLanguage: true
+      readonly: false
+      hidden: false
+      sort: 11
+      width: full
+      translations: null
+      note: null
+      conditions: null
+      required: false
+      group: null
+  - collection: pack_templates
+    field: nft_templates
+    type: alias
+    schema: null
+    meta:
+      collection: pack_templates
+      field: nft_templates
+      special:
+        - o2m
+      interface: list-o2m
+      options:
+        enableCreate: false
+        template: '{{unique_code}}'
+        filter:
+          _and:
+            - pack_template:
+                id:
+                  _null: true
+      display: null
+      display_options: null
+      readonly: false
+      hidden: false
+      sort: 20
+      width: full
+      translations:
+        - language: en-US
+          translation: NFT Templates
+      note: null
+      conditions:
+        - name: Required if status Published
+          rule:
+            _and:
+              - status:
+                  _contains: published
+          required: true
+        - name: No editing after publish
+          rule:
+            _and:
+              - status:
+                  _eq: published
+              - id:
+                  _nnull: true
+          readonly: true
+      required: false
+      group: null
+relations:
   - collection: application_countries
     field: application_id
     related_collection: application
     schema:
+      constraint_name: application_countries_application_id_foreign
       table: application_countries
       column: application_id
+      foreign_key_schema: public
       foreign_key_table: application
       foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: application_countries_application_id_foreign
       on_update: NO ACTION
       on_delete: SET NULL
     meta:
@@ -5841,44 +5891,44 @@ relations:
       junction_field: countries_code
       sort_field: null
       one_deselect_action: nullify
-  - collection: collections
-    field: user_created
-    related_collection: directus_users
+  - collection: application_countries
+    field: countries_code
+    related_collection: countries
     schema:
-      table: collections
-      column: user_created
-      foreign_key_table: directus_users
-      foreign_key_column: id
+      constraint_name: application_countries_countries_code_foreign
+      table: application_countries
+      column: countries_code
       foreign_key_schema: public
-      constraint_name: collections_user_created_foreign
+      foreign_key_table: countries
+      foreign_key_column: code
       on_update: NO ACTION
-      on_delete: NO ACTION
+      on_delete: SET NULL
     meta:
-      many_collection: collections
-      many_field: user_created
-      one_collection: directus_users
+      many_collection: application_countries
+      many_field: countries_code
+      one_collection: countries
       one_field: null
       one_collection_field: null
       one_allowed_collections: null
-      junction_field: null
+      junction_field: application_id
       sort_field: null
       one_deselect_action: nullify
   - collection: collections
-    field: user_updated
-    related_collection: directus_users
+    field: reward_image
+    related_collection: directus_files
     schema:
+      constraint_name: collections_reward_image_foreign
       table: collections
-      column: user_updated
-      foreign_key_table: directus_users
-      foreign_key_column: id
+      column: reward_image
       foreign_key_schema: public
-      constraint_name: collections_user_updated_foreign
+      foreign_key_table: directus_files
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
       many_collection: collections
-      many_field: user_updated
-      one_collection: directus_users
+      many_field: reward_image
+      one_collection: directus_files
       one_field: null
       one_collection_field: null
       one_allowed_collections: null
@@ -5889,12 +5939,12 @@ relations:
     field: collection_image
     related_collection: directus_files
     schema:
+      constraint_name: collections_collection_image_foreign
       table: collections
       column: collection_image
+      foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: collections_collection_image_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
@@ -5908,21 +5958,43 @@ relations:
       sort_field: null
       one_deselect_action: nullify
   - collection: collections
-    field: reward_image
-    related_collection: directus_files
+    field: user_updated
+    related_collection: directus_users
     schema:
+      constraint_name: collections_user_updated_foreign
       table: collections
-      column: reward_image
-      foreign_key_table: directus_files
-      foreign_key_column: id
+      column: user_updated
       foreign_key_schema: public
-      constraint_name: collections_reward_image_foreign
+      foreign_key_table: directus_users
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
       many_collection: collections
-      many_field: reward_image
-      one_collection: directus_files
+      many_field: user_updated
+      one_collection: directus_users
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: collections
+    field: user_created
+    related_collection: directus_users
+    schema:
+      constraint_name: collections_user_created_foreign
+      table: collections
+      column: user_created
+      foreign_key_schema: public
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: collections
+      many_field: user_created
+      one_collection: directus_users
       one_field: null
       one_collection_field: null
       one_allowed_collections: null
@@ -5930,37 +6002,15 @@ relations:
       sort_field: null
       one_deselect_action: nullify
   - collection: collections_translations
-    field: collections_id
-    related_collection: collections
-    schema:
-      table: collections_translations
-      column: collections_id
-      foreign_key_table: collections
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: collections_translations_collections_id_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: collections_translations
-      many_field: collections_id
-      one_collection: collections
-      one_field: translations
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: languages_code
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: collections_translations
     field: languages_code
     related_collection: languages
     schema:
+      constraint_name: collections_translations_languages_code_foreign
       table: collections_translations
       column: languages_code
+      foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
-      foreign_key_schema: public
-      constraint_name: collections_translations_languages_code_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
@@ -5973,38 +6023,38 @@ relations:
       junction_field: collections_id
       sort_field: null
       one_deselect_action: nullify
-  - collection: countries_translations
-    field: languages_code
-    related_collection: languages
+  - collection: collections_translations
+    field: collections_id
+    related_collection: collections
     schema:
-      table: countries_translations
-      column: languages_code
-      foreign_key_table: languages
-      foreign_key_column: code
+      constraint_name: collections_translations_collections_id_foreign
+      table: collections_translations
+      column: collections_id
       foreign_key_schema: public
-      constraint_name: countries_translations_languages_code_foreign
+      foreign_key_table: collections
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: countries_translations
-      many_field: languages_code
-      one_collection: languages
-      one_field: null
+      many_collection: collections_translations
+      many_field: collections_id
+      one_collection: collections
+      one_field: translations
       one_collection_field: null
       one_allowed_collections: null
-      junction_field: countries_code
+      junction_field: languages_code
       sort_field: null
       one_deselect_action: nullify
   - collection: countries_translations
     field: countries_code
     related_collection: countries
     schema:
+      constraint_name: countries_translations_countries_code_foreign
       table: countries_translations
       column: countries_code
+      foreign_key_schema: public
       foreign_key_table: countries
       foreign_key_column: code
-      foreign_key_schema: public
-      constraint_name: countries_translations_countries_code_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
@@ -6017,353 +6067,45 @@ relations:
       junction_field: languages_code
       sort_field: null
       one_deselect_action: nullify
-  - collection: homepage
-    field: featured_pack
-    related_collection: pack_templates
-    schema:
-      table: homepage
-      column: featured_pack
-      foreign_key_table: pack_templates
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: homepage_featured_pack_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: homepage
-      many_field: featured_pack
-      one_collection: pack_templates
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: user_created
-    related_collection: directus_users
-    schema:
-      table: nft_templates
-      column: user_created
-      foreign_key_table: directus_users
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_user_created_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: user_created
-      one_collection: directus_users
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: user_updated
-    related_collection: directus_users
-    schema:
-      table: nft_templates
-      column: user_updated
-      foreign_key_table: directus_users
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_user_updated_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: user_updated
-      one_collection: directus_users
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: preview_image
-    related_collection: directus_files
-    schema:
-      table: nft_templates
-      column: preview_image
-      foreign_key_table: directus_files
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_preview_image_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: preview_image
-      one_collection: directus_files
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: preview_video
-    related_collection: directus_files
-    schema:
-      table: nft_templates
-      column: preview_video
-      foreign_key_table: directus_files
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_preview_video_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: preview_video
-      one_collection: directus_files
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: preview_audio
-    related_collection: directus_files
-    schema:
-      table: nft_templates
-      column: preview_audio
-      foreign_key_table: directus_files
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_preview_audio_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: preview_audio
-      one_collection: directus_files
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: pack_template
-    related_collection: pack_templates
-    schema:
-      table: nft_templates
-      column: pack_template
-      foreign_key_table: pack_templates
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_pack_template_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: pack_template
-      one_collection: pack_templates
-      one_field: nft_templates
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: rarity
-    related_collection: rarities
-    schema:
-      table: nft_templates
-      column: rarity
-      foreign_key_table: rarities
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_rarity_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: rarity
-      one_collection: rarities
-      one_field: nft_templates
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: set
-    related_collection: sets
-    schema:
-      table: nft_templates
-      column: set
-      foreign_key_table: sets
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_set_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: set
-      one_collection: sets
-      one_field: nft_templates
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: collection
-    related_collection: collections
-    schema:
-      table: nft_templates
-      column: collection
-      foreign_key_table: collections
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_collection_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: collection
-      one_collection: collections
-      one_field: nft_templates
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: homepage
-    related_collection: homepage
-    schema:
-      table: nft_templates
-      column: homepage
-      foreign_key_table: homepage
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_homepage_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: homepage
-      one_collection: homepage
-      one_field: notable_collectibles
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates
-    field: asset_file
-    related_collection: directus_files
-    schema:
-      table: nft_templates
-      column: asset_file
-      foreign_key_table: directus_files
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_asset_file_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates
-      many_field: asset_file
-      one_collection: directus_files
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates_translations
-    field: nft_templates_id
-    related_collection: nft_templates
-    schema:
-      table: nft_templates_translations
-      column: nft_templates_id
-      foreign_key_table: nft_templates
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: nft_templates_translations_nft_templates_id_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: nft_templates_translations
-      many_field: nft_templates_id
-      one_collection: nft_templates
-      one_field: translations
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: languages_code
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: nft_templates_translations
+  - collection: countries_translations
     field: languages_code
     related_collection: languages
     schema:
-      table: nft_templates_translations
+      constraint_name: countries_translations_languages_code_foreign
+      table: countries_translations
       column: languages_code
+      foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
-      foreign_key_schema: public
-      constraint_name: nft_templates_translations_languages_code_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: nft_templates_translations
+      many_collection: countries_translations
       many_field: languages_code
       one_collection: languages
       one_field: null
       one_collection_field: null
       one_allowed_collections: null
-      junction_field: nft_templates_id
+      junction_field: countries_code
       sort_field: null
       one_deselect_action: nullify
   - collection: pack_templates
-    field: user_created
-    related_collection: directus_users
+    field: homepage
+    related_collection: homepage
     schema:
+      constraint_name: pack_templates_homepage_foreign
       table: pack_templates
-      column: user_created
-      foreign_key_table: directus_users
-      foreign_key_column: id
+      column: homepage
       foreign_key_schema: public
-      constraint_name: pack_templates_user_created_foreign
+      foreign_key_table: homepage
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
       many_collection: pack_templates
-      many_field: user_created
-      one_collection: directus_users
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: null
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: pack_templates
-    field: user_updated
-    related_collection: directus_users
-    schema:
-      table: pack_templates
-      column: user_updated
-      foreign_key_table: directus_users
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: pack_templates_user_updated_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: pack_templates
-      many_field: user_updated
-      one_collection: directus_users
-      one_field: null
+      many_field: homepage
+      one_collection: homepage
+      one_field: upcoming_packs
       one_collection_field: null
       one_allowed_collections: null
       junction_field: null
@@ -6373,12 +6115,12 @@ relations:
     field: pack_image
     related_collection: directus_files
     schema:
+      constraint_name: pack_templates_pack_image_foreign
       table: pack_templates
       column: pack_image
+      foreign_key_schema: public
       foreign_key_table: directus_files
       foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: pack_templates_pack_image_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
@@ -6392,217 +6134,305 @@ relations:
       sort_field: null
       one_deselect_action: nullify
   - collection: pack_templates
-    field: homepage
-    related_collection: homepage
+    field: user_updated
+    related_collection: directus_users
     schema:
+      constraint_name: pack_templates_user_updated_foreign
       table: pack_templates
-      column: homepage
-      foreign_key_table: homepage
-      foreign_key_column: id
+      column: user_updated
       foreign_key_schema: public
-      constraint_name: pack_templates_homepage_foreign
+      foreign_key_table: directus_users
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
       many_collection: pack_templates
-      many_field: homepage
-      one_collection: homepage
-      one_field: upcoming_packs
+      many_field: user_updated
+      one_collection: directus_users
+      one_field: null
       one_collection_field: null
       one_allowed_collections: null
       junction_field: null
       sort_field: null
       one_deselect_action: nullify
-  - collection: pack_templates_directus_files
-    field: directus_files_id
-    related_collection: directus_files
+  - collection: pack_templates
+    field: user_created
+    related_collection: directus_users
     schema:
-      table: pack_templates_directus_files
-      column: directus_files_id
-      foreign_key_table: directus_files
-      foreign_key_column: id
+      constraint_name: pack_templates_user_created_foreign
+      table: pack_templates
+      column: user_created
       foreign_key_schema: public
-      constraint_name: pack_templates_directus_files_directus_files_id_foreign
+      foreign_key_table: directus_users
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: pack_templates_directus_files
-      many_field: directus_files_id
+      many_collection: pack_templates
+      many_field: user_created
+      one_collection: directus_users
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: homepage
+    field: featured_pack
+    related_collection: pack_templates
+    schema:
+      constraint_name: homepage_featured_pack_foreign
+      table: homepage
+      column: featured_pack
+      foreign_key_schema: public
+      foreign_key_table: pack_templates
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: homepage
+      many_field: featured_pack
+      one_collection: pack_templates
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: nft_templates
+    field: asset_file
+    related_collection: directus_files
+    schema:
+      constraint_name: nft_templates_asset_file_foreign
+      table: nft_templates
+      column: asset_file
+      foreign_key_schema: public
+      foreign_key_table: directus_files
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: nft_templates
+      many_field: asset_file
       one_collection: directus_files
       one_field: null
       one_collection_field: null
       one_allowed_collections: null
-      junction_field: pack_templates_id
+      junction_field: null
       sort_field: null
       one_deselect_action: nullify
-  - collection: pack_templates_directus_files
-    field: pack_templates_id
-    related_collection: pack_templates
+  - collection: nft_templates
+    field: homepage
+    related_collection: homepage
     schema:
-      table: pack_templates_directus_files
-      column: pack_templates_id
-      foreign_key_table: pack_templates
+      constraint_name: nft_templates_homepage_foreign
+      table: nft_templates
+      column: homepage
+      foreign_key_schema: public
+      foreign_key_table: homepage
       foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: pack_templates_directus_files_pack_templates_id_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: pack_templates_directus_files
-      many_field: pack_templates_id
-      one_collection: pack_templates
-      one_field: additional_images
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: directus_files_id
-      sort_field: sort
-      one_deselect_action: nullify
-  - collection: pack_templates_translations
-    field: pack_templates_id
-    related_collection: pack_templates
-    schema:
-      table: pack_templates_translations
-      column: pack_templates_id
-      foreign_key_table: pack_templates
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: pack_templates_translations_pack_templates_id_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: pack_templates_translations
-      many_field: pack_templates_id
-      one_collection: pack_templates
-      one_field: translations
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: languages_code
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: pack_templates_translations
-    field: languages_code
-    related_collection: languages
-    schema:
-      table: pack_templates_translations
-      column: languages_code
-      foreign_key_table: languages
-      foreign_key_column: code
-      foreign_key_schema: public
-      constraint_name: pack_templates_translations_languages_code_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: pack_templates_translations
-      many_field: languages_code
-      one_collection: languages
-      one_field: null
-      one_collection_field: null
-      one_allowed_collections: null
-      junction_field: pack_templates_id
-      sort_field: null
-      one_deselect_action: nullify
-  - collection: rarities
-    field: user_created
-    related_collection: directus_users
-    schema:
-      table: rarities
-      column: user_created
-      foreign_key_table: directus_users
-      foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: rarities_user_created_foreign
-      on_update: NO ACTION
-      on_delete: NO ACTION
-    meta:
-      many_collection: rarities
-      many_field: user_created
-      one_collection: directus_users
-      one_field: null
+      many_collection: nft_templates
+      many_field: homepage
+      one_collection: homepage
+      one_field: notable_collectibles
       one_collection_field: null
       one_allowed_collections: null
       junction_field: null
       sort_field: null
       one_deselect_action: nullify
-  - collection: rarities
-    field: user_updated
-    related_collection: directus_users
+  - collection: nft_templates
+    field: collection
+    related_collection: collections
     schema:
-      table: rarities
-      column: user_updated
-      foreign_key_table: directus_users
-      foreign_key_column: id
+      constraint_name: nft_templates_collection_foreign
+      table: nft_templates
+      column: collection
       foreign_key_schema: public
-      constraint_name: rarities_user_updated_foreign
+      foreign_key_table: collections
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: rarities
-      many_field: user_updated
-      one_collection: directus_users
-      one_field: null
+      many_collection: nft_templates
+      many_field: collection
+      one_collection: collections
+      one_field: nft_templates
       one_collection_field: null
       one_allowed_collections: null
       junction_field: null
       sort_field: null
       one_deselect_action: nullify
-  - collection: rarities_translations
-    field: rarities_id
+  - collection: nft_templates
+    field: set
+    related_collection: sets
+    schema:
+      constraint_name: nft_templates_set_foreign
+      table: nft_templates
+      column: set
+      foreign_key_schema: public
+      foreign_key_table: sets
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: nft_templates
+      many_field: set
+      one_collection: sets
+      one_field: nft_templates
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: nft_templates
+    field: rarity
     related_collection: rarities
     schema:
-      table: rarities_translations
-      column: rarities_id
+      constraint_name: nft_templates_rarity_foreign
+      table: nft_templates
+      column: rarity
+      foreign_key_schema: public
       foreign_key_table: rarities
       foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: rarities_translations_rarities_id_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: rarities_translations
-      many_field: rarities_id
+      many_collection: nft_templates
+      many_field: rarity
       one_collection: rarities
-      one_field: translations
+      one_field: nft_templates
       one_collection_field: null
       one_allowed_collections: null
-      junction_field: languages_code
+      junction_field: null
       sort_field: null
       one_deselect_action: nullify
-  - collection: rarities_translations
-    field: languages_code
-    related_collection: languages
+  - collection: nft_templates
+    field: pack_template
+    related_collection: pack_templates
     schema:
-      table: rarities_translations
-      column: languages_code
-      foreign_key_table: languages
-      foreign_key_column: code
+      constraint_name: nft_templates_pack_template_foreign
+      table: nft_templates
+      column: pack_template
       foreign_key_schema: public
-      constraint_name: rarities_translations_languages_code_foreign
+      foreign_key_table: pack_templates
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: rarities_translations
-      many_field: languages_code
-      one_collection: languages
+      many_collection: nft_templates
+      many_field: pack_template
+      one_collection: pack_templates
+      one_field: nft_templates
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: nft_templates
+    field: preview_audio
+    related_collection: directus_files
+    schema:
+      constraint_name: nft_templates_preview_audio_foreign
+      table: nft_templates
+      column: preview_audio
+      foreign_key_schema: public
+      foreign_key_table: directus_files
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: nft_templates
+      many_field: preview_audio
+      one_collection: directus_files
       one_field: null
       one_collection_field: null
       one_allowed_collections: null
-      junction_field: rarities_id
+      junction_field: null
       sort_field: null
       one_deselect_action: nullify
-  - collection: sets
-    field: user_created
-    related_collection: directus_users
+  - collection: nft_templates
+    field: preview_video
+    related_collection: directus_files
     schema:
-      table: sets
-      column: user_created
-      foreign_key_table: directus_users
-      foreign_key_column: id
+      constraint_name: nft_templates_preview_video_foreign
+      table: nft_templates
+      column: preview_video
       foreign_key_schema: public
-      constraint_name: sets_user_created_foreign
+      foreign_key_table: directus_files
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: sets
+      many_collection: nft_templates
+      many_field: preview_video
+      one_collection: directus_files
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: nft_templates
+    field: preview_image
+    related_collection: directus_files
+    schema:
+      constraint_name: nft_templates_preview_image_foreign
+      table: nft_templates
+      column: preview_image
+      foreign_key_schema: public
+      foreign_key_table: directus_files
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: nft_templates
+      many_field: preview_image
+      one_collection: directus_files
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: nft_templates
+    field: user_updated
+    related_collection: directus_users
+    schema:
+      constraint_name: nft_templates_user_updated_foreign
+      table: nft_templates
+      column: user_updated
+      foreign_key_schema: public
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: nft_templates
+      many_field: user_updated
+      one_collection: directus_users
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: nft_templates
+    field: user_created
+    related_collection: directus_users
+    schema:
+      constraint_name: nft_templates_user_created_foreign
+      table: nft_templates
+      column: user_created
+      foreign_key_schema: public
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: nft_templates
       many_field: user_created
       one_collection: directus_users
       one_field: null
@@ -6611,21 +6441,43 @@ relations:
       junction_field: null
       sort_field: null
       one_deselect_action: nullify
-  - collection: sets
+  - collection: rarities
     field: user_updated
     related_collection: directus_users
     schema:
-      table: sets
+      constraint_name: rarities_user_updated_foreign
+      table: rarities
       column: user_updated
+      foreign_key_schema: public
       foreign_key_table: directus_users
       foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: sets_user_updated_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: sets
+      many_collection: rarities
       many_field: user_updated
+      one_collection: directus_users
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: rarities
+    field: user_created
+    related_collection: directus_users
+    schema:
+      constraint_name: rarities_user_created_foreign
+      table: rarities
+      column: user_created
+      foreign_key_schema: public
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: rarities
+      many_field: user_created
       one_collection: directus_users
       one_field: null
       one_collection_field: null
@@ -6637,12 +6489,12 @@ relations:
     field: collection
     related_collection: collections
     schema:
+      constraint_name: sets_collection_foreign
       table: sets
       column: collection
+      foreign_key_schema: public
       foreign_key_table: collections
       foreign_key_column: id
-      foreign_key_schema: public
-      constraint_name: sets_collection_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
@@ -6655,22 +6507,220 @@ relations:
       junction_field: null
       sort_field: null
       one_deselect_action: nullify
-  - collection: sets_translations
-    field: sets_id
-    related_collection: sets
+  - collection: sets
+    field: user_updated
+    related_collection: directus_users
     schema:
-      table: sets_translations
-      column: sets_id
-      foreign_key_table: sets
-      foreign_key_column: id
+      constraint_name: sets_user_updated_foreign
+      table: sets
+      column: user_updated
       foreign_key_schema: public
-      constraint_name: sets_translations_sets_id_foreign
+      foreign_key_table: directus_users
+      foreign_key_column: id
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
-      many_collection: sets_translations
-      many_field: sets_id
-      one_collection: sets
+      many_collection: sets
+      many_field: user_updated
+      one_collection: directus_users
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: sets
+    field: user_created
+    related_collection: directus_users
+    schema:
+      constraint_name: sets_user_created_foreign
+      table: sets
+      column: user_created
+      foreign_key_schema: public
+      foreign_key_table: directus_users
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: sets
+      many_field: user_created
+      one_collection: directus_users
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: null
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: nft_templates_translations
+    field: languages_code
+    related_collection: languages
+    schema:
+      constraint_name: nft_templates_translations_languages_code_foreign
+      table: nft_templates_translations
+      column: languages_code
+      foreign_key_schema: public
+      foreign_key_table: languages
+      foreign_key_column: code
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: nft_templates_translations
+      many_field: languages_code
+      one_collection: languages
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: nft_templates_id
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: nft_templates_translations
+    field: nft_templates_id
+    related_collection: nft_templates
+    schema:
+      constraint_name: nft_templates_translations_nft_templates_id_foreign
+      table: nft_templates_translations
+      column: nft_templates_id
+      foreign_key_schema: public
+      foreign_key_table: nft_templates
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: nft_templates_translations
+      many_field: nft_templates_id
+      one_collection: nft_templates
+      one_field: translations
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: languages_code
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: pack_templates_directus_files
+    field: pack_templates_id
+    related_collection: pack_templates
+    schema:
+      constraint_name: pack_templates_directus_files_pack_templates_id_foreign
+      table: pack_templates_directus_files
+      column: pack_templates_id
+      foreign_key_schema: public
+      foreign_key_table: pack_templates
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: pack_templates_directus_files
+      many_field: pack_templates_id
+      one_collection: pack_templates
+      one_field: additional_images
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: directus_files_id
+      sort_field: sort
+      one_deselect_action: nullify
+  - collection: pack_templates_directus_files
+    field: directus_files_id
+    related_collection: directus_files
+    schema:
+      constraint_name: pack_templates_directus_files_directus_files_id_foreign
+      table: pack_templates_directus_files
+      column: directus_files_id
+      foreign_key_schema: public
+      foreign_key_table: directus_files
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: pack_templates_directus_files
+      many_field: directus_files_id
+      one_collection: directus_files
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: pack_templates_id
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: pack_templates_translations
+    field: languages_code
+    related_collection: languages
+    schema:
+      constraint_name: pack_templates_translations_languages_code_foreign
+      table: pack_templates_translations
+      column: languages_code
+      foreign_key_schema: public
+      foreign_key_table: languages
+      foreign_key_column: code
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: pack_templates_translations
+      many_field: languages_code
+      one_collection: languages
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: pack_templates_id
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: pack_templates_translations
+    field: pack_templates_id
+    related_collection: pack_templates
+    schema:
+      constraint_name: pack_templates_translations_pack_templates_id_foreign
+      table: pack_templates_translations
+      column: pack_templates_id
+      foreign_key_schema: public
+      foreign_key_table: pack_templates
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: pack_templates_translations
+      many_field: pack_templates_id
+      one_collection: pack_templates
+      one_field: translations
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: languages_code
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: rarities_translations
+    field: languages_code
+    related_collection: languages
+    schema:
+      constraint_name: rarities_translations_languages_code_foreign
+      table: rarities_translations
+      column: languages_code
+      foreign_key_schema: public
+      foreign_key_table: languages
+      foreign_key_column: code
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: rarities_translations
+      many_field: languages_code
+      one_collection: languages
+      one_field: null
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: rarities_id
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: rarities_translations
+    field: rarities_id
+    related_collection: rarities
+    schema:
+      constraint_name: rarities_translations_rarities_id_foreign
+      table: rarities_translations
+      column: rarities_id
+      foreign_key_schema: public
+      foreign_key_table: rarities
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: rarities_translations
+      many_field: rarities_id
+      one_collection: rarities
       one_field: translations
       one_collection_field: null
       one_allowed_collections: null
@@ -6681,12 +6731,12 @@ relations:
     field: languages_code
     related_collection: languages
     schema:
+      constraint_name: sets_translations_languages_code_foreign
       table: sets_translations
       column: languages_code
+      foreign_key_schema: public
       foreign_key_table: languages
       foreign_key_column: code
-      foreign_key_schema: public
-      constraint_name: sets_translations_languages_code_foreign
       on_update: NO ACTION
       on_delete: NO ACTION
     meta:
@@ -6697,5 +6747,27 @@ relations:
       one_collection_field: null
       one_allowed_collections: null
       junction_field: sets_id
+      sort_field: null
+      one_deselect_action: nullify
+  - collection: sets_translations
+    field: sets_id
+    related_collection: sets
+    schema:
+      constraint_name: sets_translations_sets_id_foreign
+      table: sets_translations
+      column: sets_id
+      foreign_key_schema: public
+      foreign_key_table: sets
+      foreign_key_column: id
+      on_update: NO ACTION
+      on_delete: NO ACTION
+    meta:
+      many_collection: sets_translations
+      many_field: sets_id
+      one_collection: sets
+      one_field: translations
+      one_collection_field: null
+      one_allowed_collections: null
+      junction_field: languages_code
       sort_field: null
       one_deselect_action: nullify

--- a/apps/cms/snapshot.yml
+++ b/apps/cms/snapshot.yml
@@ -1040,15 +1040,7 @@ fields:
       width: half
       translations: null
       note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
+      conditions: null
       required: false
       group: null
   - collection: collections
@@ -1262,7 +1254,7 @@ fields:
       table: collections
       schema: public
       data_type: character varying
-      is_nullable: false
+      is_nullable: true
       generation_expression: null
       default_value: null
       is_generated: false
@@ -1292,16 +1284,8 @@ fields:
       width: half
       translations: null
       note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
-      required: false
+      conditions: null
+      required: true
       group: null
   - collection: collections
     field: collection_image
@@ -2164,7 +2148,7 @@ fields:
       sort: 7
       width: half
       translations: null
-      note: null
+      note: Most fields will not be editable once published.
       conditions:
         - name: No editing after publish
           rule:
@@ -2376,7 +2360,7 @@ fields:
       sort: 8
       width: half
       translations: null
-      note: null
+      note: Number of NFT editions that will be minted for this NFT Template.
       conditions:
         - name: No editing after publish
           rule:
@@ -2424,7 +2408,9 @@ fields:
       sort: 9
       width: half
       translations: null
-      note: null
+      note: >-
+        Eight character unique code that is displayed with the Algorand Standard
+        Asset on the blockchain.
       conditions:
         - name: No editing after publish
           rule:
@@ -2481,7 +2467,7 @@ fields:
               - id:
                   _nnull: true
           readonly: true
-          required: false
+          required: true
           options:
             crop: false
       required: true
@@ -2633,26 +2619,17 @@ fields:
       interface: select-dropdown-m2o
       options:
         template: '{{slug}}'
-        filter:
-          _and:
-            - status:
-                _ncontains: published
+        filter: null
       display: related-values
       display_options:
         template: '{{slug}}'
-      readonly: false
+      readonly: true
       hidden: false
       sort: 11
       width: full
       translations: null
-      note: null
+      note: Must be configured via the Pack Template.
       conditions:
-        - name: Required if status is Published
-          rule:
-            _and:
-              - status:
-                  _contains: published
-          required: true
         - name: No editing after publish
           rule:
             _and:
@@ -2701,7 +2678,7 @@ fields:
       sort: 10
       width: half
       translations: null
-      note: null
+      note: Optional rarity color and name for this NFT.
       conditions:
         - name: No editing after publish
           rule:
@@ -2751,15 +2728,14 @@ fields:
       sort: 12
       width: half
       translations: null
-      note: null
+      note: Optional Set to organize this NFT Template under.
       conditions:
-        - name: No editing after publish
+        - name: Cannot set Set and Collection
           rule:
             _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
+              - collection:
+                  id:
+                    _nnull: true
           readonly: true
       required: false
       group: null
@@ -2801,15 +2777,16 @@ fields:
       sort: 13
       width: half
       translations: null
-      note: null
+      note: >-
+        Optional Collection to organize this NFT Template under. Select this or
+        Set, but not both.
       conditions:
-        - name: No editing after publish
+        - name: Cannot set Collection and Set
           rule:
             _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
+              - set:
+                  id:
+                    _nnull: true
           readonly: true
       required: false
       group: null
@@ -4985,15 +4962,7 @@ fields:
       width: half
       translations: null
       note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
+      conditions: null
       required: false
       group: null
   - collection: sets
@@ -5207,7 +5176,7 @@ fields:
       table: sets
       schema: public
       data_type: character varying
-      is_nullable: false
+      is_nullable: true
       generation_expression: null
       default_value: null
       is_generated: false
@@ -5237,16 +5206,8 @@ fields:
       width: half
       translations: null
       note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
-      required: false
+      conditions: null
+      required: true
       group: null
   - collection: sets
     field: collection
@@ -5284,18 +5245,10 @@ fields:
       readonly: false
       hidden: false
       sort: 9
-      width: fill
+      width: full
       translations: null
       note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
+      conditions: null
       required: false
       group: null
   - collection: sets_translations
@@ -5504,30 +5457,29 @@ fields:
       required: false
       group: null
   - collection: collections
-    field: translations
+    field: nft_templates
     type: alias
     schema: null
     meta:
       collection: collections
-      field: translations
+      field: nft_templates
       special:
-        - translations
-      interface: translations
+        - o2m
+      interface: list-o2m
       options:
-        languageTemplate: '{{name}}'
-        translationsTemplate: '{{name}}'
-        languageField: code
-      display: translations
+        enableCreate: false
+        enableSelect: true
+        template: "{{preview_image}}\_{{unique_code}}"
+      display: related-values
       display_options:
-        template: '{{name}}'
-        languageField: code
-        defaultLanguage: en-US
-        userLanguage: true
+        template: "{{preview_image}}\_{{unique_code}}"
       readonly: false
       hidden: false
-      sort: 13
+      sort: 12
       width: full
-      translations: null
+      translations:
+        - language: en-US
+          translation: NFT Templates
       note: null
       conditions: null
       required: false
@@ -5554,50 +5506,7 @@ fields:
       width: full
       translations: null
       note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
-      required: false
-      group: null
-  - collection: collections
-    field: nft_templates
-    type: alias
-    schema: null
-    meta:
-      collection: collections
-      field: nft_templates
-      special:
-        - o2m
-      interface: list-o2m
-      options:
-        enableCreate: false
-        enableSelect: true
-        template: '{{unique_code}}'
-      display: null
-      display_options: null
-      readonly: false
-      hidden: false
-      sort: 12
-      width: full
-      translations:
-        - language: en-US
-          translation: NFT Templates
-      note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
+      conditions: null
       required: false
       group: null
   - collection: countries
@@ -5650,6 +5559,35 @@ fields:
       conditions: null
       required: false
       group: null
+  - collection: collections
+    field: translations
+    type: alias
+    schema: null
+    meta:
+      collection: collections
+      field: translations
+      special:
+        - translations
+      interface: translations
+      options:
+        languageTemplate: '{{name}}'
+        translationsTemplate: '{{name}}'
+        languageField: code
+      display: translations
+      display_options:
+        template: '{{name}}'
+        languageField: code
+        defaultLanguage: en-US
+        userLanguage: true
+      readonly: false
+      hidden: false
+      sort: 13
+      width: full
+      translations: null
+      note: null
+      conditions: null
+      required: true
+      group: null
   - collection: nft_templates
     field: translations
     type: alias
@@ -5673,6 +5611,35 @@ fields:
       readonly: false
       hidden: false
       sort: 18
+      width: full
+      translations: null
+      note: null
+      conditions: null
+      required: true
+      group: null
+  - collection: sets
+    field: translations
+    type: alias
+    schema: null
+    meta:
+      collection: sets
+      field: translations
+      special:
+        - translations
+      interface: translations
+      options:
+        languageTemplate: '{{name}}'
+        translationsTemplate: '{{name}}'
+        languageField: code
+      display: translations
+      display_options:
+        template: '{{name}}'
+        languageField: code
+        defaultLanguage: en-US
+        userLanguage: true
+      readonly: false
+      hidden: false
+      sort: 11
       width: full
       translations: null
       note: null
@@ -5772,9 +5739,10 @@ fields:
       options:
         enableCreate: false
         enableSelect: true
-        template: '{{unique_code}}'
-      display: null
-      display_options: null
+        template: "{{preview_image}}\_{{unique_code}}"
+      display: related-values
+      display_options:
+        template: "{{preview_image}}\_{{unique_code}}"
       readonly: false
       hidden: false
       sort: 10
@@ -5782,43 +5750,6 @@ fields:
       translations:
         - language: en-US
           translation: NFT Templates
-      note: null
-      conditions:
-        - name: No editing after publish
-          rule:
-            _and:
-              - status:
-                  _eq: published
-              - id:
-                  _nnull: true
-          readonly: true
-      required: false
-      group: null
-  - collection: sets
-    field: translations
-    type: alias
-    schema: null
-    meta:
-      collection: sets
-      field: translations
-      special:
-        - translations
-      interface: translations
-      options:
-        languageTemplate: '{{name}}'
-        translationsTemplate: '{{name}}'
-        languageField: code
-      display: translations
-      display_options:
-        template: '{{name}}'
-        languageField: code
-        defaultLanguage: en-US
-        userLanguage: true
-      readonly: false
-      hidden: false
-      sort: 11
-      width: full
-      translations: null
       note: null
       conditions: null
       required: false


### PR DESCRIPTION
**Changes:**

- Adds filters when:
  - selecting Pack Template for NFT Template
  - selecting NFT Templates for Pack Template 
- Adds some more notes/comments for various fields.
- Adds required flags for many fields (that were not nullable).
- Re-order some fields in the Directus UI.
- Adds conditions to enforce required Price and Auction Until values for Pack Template.
- Show translation Name/Title where available (may not always work).
- Make Pack Template a readonly field on NFT Template
- Disallow setting both Set and Collection on an NFT Template
- Add a few more field notes
- Allow edits to Sets and Collections after being published

Apologies for the `public` changes, must be a difference in Directus 9.4.x to 9.5.x in how they serialize the schemas.