### PR TITLE
Force single instance for Web, API, and CMS

### DIFF
--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -42,7 +42,7 @@ resource "google_cloud_run_service" "api" {
         # maxScale is very conservative due to background tasks not needing
         # to scale up (and opening up unnecessary connection pools) and
         # fastify being highly capable of handling a decent amount of traffic.
-        "autoscaling.knative.dev/maxScale" = 2
+        "autoscaling.knative.dev/maxScale" = 1
       }
     }
 

--- a/terraform/cloud_run_cms.tf
+++ b/terraform/cloud_run_cms.tf
@@ -22,9 +22,10 @@ resource "google_cloud_run_service" "cms" {
       annotations = {
         "run.googleapis.com/vpc-access-connector" = var.vpc_access_connector_name
 
-        # maxScale to limit database connections; it is unlikely that there
-        # will ever be more than a single container running
-        "autoscaling.knative.dev/maxScale" = 2
+        # Limit the CMS to run a single instance at all times
+        # This may need to be tweaked to improve performance on a per-project basis
+        "autoscaling.knative.dev/minScale" = 1
+        "autoscaling.knative.dev/maxScale" = 1
       }
     }
 

--- a/terraform/cloud_run_web.tf
+++ b/terraform/cloud_run_web.tf
@@ -7,6 +7,13 @@ resource "google_cloud_run_service" "web" {
   template {
     metadata {
       name = var.web_revision_name
+
+      annotations = {
+        # Limit the Web to run a single instance at all times
+        # This may need to be tweaked to improve performance on a per-project basis
+        "autoscaling.knative.dev/minScale" = 1
+        "autoscaling.knative.dev/maxScale" = 1
+      }
     }
 
     spec {


### PR DESCRIPTION
Just noticed that the Web instance at demo.algomart.dev scales from 0 to 100 instances. To make this demo site more conservative of its resources I'm hard-coding the min/max for each to 1/1. 