### PR TITLE
WIP: Add sell NFT UI + API

### DIFF
--- a/apps/api/src/migrations/20220325194510_AddCollectibleAuctionSetupTransactionId.ts
+++ b/apps/api/src/migrations/20220325194510_AddCollectibleAuctionSetupTransactionId.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('CollectibleAuction', (table) => {
+    table
+      .uuid('setupTransactionId')
+      .nullable()
+      .references('id')
+      .inTable('AlgorandTransaction')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('CollectibleAuction', (table) => {
+    table.dropColumn('setupTransactionId')
+  })
+}

--- a/apps/api/src/modules/auctions/auctions.routes.ts
+++ b/apps/api/src/modules/auctions/auctions.routes.ts
@@ -16,7 +16,7 @@ export async function createAuction(
     .getContainer()
     .get<AuctionsService>(AuctionsService.name)
 
-  await service.createAuction(request.body, Configuration.secret)
+  await service.createAuction(request.body, 5, request.transaction)
 
   reply.status(201).send()
 }

--- a/apps/api/src/modules/auctions/auctions.routes.ts
+++ b/apps/api/src/modules/auctions/auctions.routes.ts
@@ -1,4 +1,4 @@
-import { CreateAuctionBody } from '@algomart/schemas'
+import { CreateAuctionBody, SetupAuctionBody } from '@algomart/schemas'
 import { AuctionsService } from '@algomart/shared/services'
 import { Configuration } from '@api/configuration'
 import { FastifyReply, FastifyRequest } from 'fastify'
@@ -16,7 +16,29 @@ export async function createAuction(
     .getContainer()
     .get<AuctionsService>(AuctionsService.name)
 
-  await service.createAuction(request.body, 5, request.transaction)
+  const result = await service.createAuction(
+    request.body,
+    5,
+    request.transaction
+  )
 
-  reply.status(201).send()
+  reply.send(result)
+}
+
+export async function setupAuction(
+  request: FastifyRequest<{ Body: SetupAuctionBody }>,
+  reply: FastifyReply
+) {
+  if (!Configuration.enableMarketplace) {
+    reply.status(501).send('Marketplace is not implemented yet')
+    return
+  }
+
+  const service = request
+    .getContainer()
+    .get<AuctionsService>(AuctionsService.name)
+
+  const result = await service.setupAuction(request.body, request.transaction)
+
+  reply.send(result)
 }

--- a/apps/api/src/modules/auctions/index.ts
+++ b/apps/api/src/modules/auctions/index.ts
@@ -1,10 +1,13 @@
-import { CreateAuctionBodySchema } from '@algomart/schemas'
+import {
+  CreateAuctionBodySchema,
+  SetupAuctionBodySchema,
+} from '@algomart/schemas'
 import { appErrorHandler } from '@algomart/shared/utils'
 import bearerAuthOptions from '@api/configuration/bearer-auth'
 import { FastifyInstance } from 'fastify'
 import fastifyBearerAuth from 'fastify-bearer-auth'
 
-import { createAuction } from './auctions.routes'
+import { createAuction, setupAuction } from './auctions.routes'
 
 export async function auctionsRoutes(app: FastifyInstance) {
   // Helps with organization in the Swagger docs
@@ -21,16 +24,29 @@ export async function auctionsRoutes(app: FastifyInstance) {
   // Plugins
   await app.register(fastifyBearerAuth, bearerAuthOptions)
 
-  app.post(
-    '/',
-    {
-      transact: true,
-      schema: {
-        tags,
-        security,
-        body: CreateAuctionBodySchema,
+  app
+    .post(
+      '/',
+      {
+        transact: true,
+        schema: {
+          tags,
+          security,
+          body: CreateAuctionBodySchema,
+        },
       },
-    },
-    createAuction
-  )
+      createAuction
+    )
+    .post(
+      '/setup',
+      {
+        transact: true,
+        schema: {
+          tags,
+          security,
+          body: SetupAuctionBodySchema,
+        },
+      },
+      setupAuction
+    )
 }

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,3 +21,6 @@ NEXT_PUBLIC_WIRE_PAYMENT_ENABLED=false
 
 # Enables or disables the crypto payment functionality
 NEXT_PUBLIC_CRYPTO_PAYMENT_ENABLED=false
+
+# Enables or disables secondary marketplace
+NEXT_PUBLIC_MARKETPLACE_ENABLED=false

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -43,6 +43,8 @@ module.exports = withNx(
       NEXT_PUBLIC_CRYPTO_PAYMENT_ENABLED:
         process.env.NEXT_PUBLIC_CRYPTO_PAYMENT_ENABLED,
       NODE_ENV: process.env.NODE_ENV,
+      NEXT_PUBLIC_MARKETPLACE_ENABLED:
+        process.env.NEXT_PUBLIC_MARKETPLACE_ENABLED,
     },
     redirects: async () => [],
   })

--- a/apps/web/src/clients/api-client.ts
+++ b/apps/web/src/clients/api-client.ts
@@ -261,6 +261,12 @@ export class ApiClient {
     return await this.http
       .get<CollectibleWithDetails>('collectibles/find-one', { params: request })
       .then((response) => response.data)
+      .catch((error) => {
+        if (axios.isAxiosError(error) && error.response.status === 404) {
+          return null
+        }
+        throw error
+      })
   }
   //#endregion
 

--- a/apps/web/src/components/link-button.tsx
+++ b/apps/web/src/components/link-button.tsx
@@ -56,7 +56,7 @@ export default function LinkButton({
         })}
         {...rest}
       >
-        {children}
+        <span className="flex items-center justify-center">{children}</span>
       </a>
     </Link>
   )

--- a/apps/web/src/components/passphrase-input/passphrase-input.module.css
+++ b/apps/web/src/components/passphrase-input/passphrase-input.module.css
@@ -7,7 +7,7 @@
 }
 
 .helpText {
-  @apply w-1/2 mt-1 text-sm font-light text-right text-base-gray-medium;
+  @apply w-1/2 mt-1 text-sm font-light text-right text-base-textTertiary;
 }
 
 .errorText {

--- a/apps/web/src/environment.ts
+++ b/apps/web/src/environment.ts
@@ -71,4 +71,9 @@ export const Environment = {
     const isEnabled = this.config('NEXT_PUBLIC_CRYPTO_PAYMENT_ENABLED', '')
     return isEnabled.toLowerCase() === 'true'
   },
+
+  get isMarketplaceEnabled() {
+    const isEnabled = this.config('NEXT_PUBLIC_MARKETPLACE_ENABLED', '')
+    return isEnabled.toLowerCase() === 'true'
+  },
 }

--- a/apps/web/src/hooks/use-convert-from-algo.ts
+++ b/apps/web/src/hooks/use-convert-from-algo.ts
@@ -1,0 +1,57 @@
+import { DEFAULT_LOCALE } from '@algomart/schemas'
+import { convert, Currency, dinero, Rates } from 'dinero.js'
+import { useMemo } from 'react'
+import useSWR from 'swr'
+
+import { ALGO } from '@/utils/format-currency'
+
+const getSpotPriceURL = (currency: string) =>
+  `https://api.coinbase.com/v2/prices/ALGO-${currency}/spot`
+
+const DEFAULT_SCALE = 6
+
+const SPOT_PRICE_REFRESH_INTERVAL = 120_000
+
+interface SpotPriceResponse {
+  data: {
+    amount: string
+    base: string
+    currency: string
+  }
+}
+
+export function toDineroRates(
+  spotPrice: SpotPriceResponse,
+  scale: number
+): Rates<number> {
+  return {
+    [spotPrice.data.currency]: {
+      amount: Math.floor(Number(spotPrice.data.amount) * 10 ** scale),
+      scale,
+    },
+  }
+}
+
+export function useConvertFromALGO(
+  amount: number,
+  targetCurrency: Currency<number>,
+  ratesScale = DEFAULT_SCALE,
+  locale = DEFAULT_LOCALE
+) {
+  const { data } = useSWR<SpotPriceResponse>(
+    getSpotPriceURL(targetCurrency.code),
+    {
+      refreshInterval: SPOT_PRICE_REFRESH_INTERVAL,
+    }
+  )
+
+  const rates = useMemo(() => {
+    if (!data) return null
+    return toDineroRates(data, ratesScale)
+  }, [data, ratesScale])
+
+  return useMemo(() => {
+    if (!rates) return null
+    return convert(dinero({ amount, currency: ALGO }), targetCurrency, rates)
+  }, [amount, rates, targetCurrency])
+}

--- a/apps/web/src/pages/nft/[assetId]/index.tsx
+++ b/apps/web/src/pages/nft/[assetId]/index.tsx
@@ -25,6 +25,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const collectible = await ApiClient.instance.getCollectible({
     assetId: Number(assetId),
   })
+
+  if (!collectible) {
+    return {
+      notFound: true,
+    }
+  }
+
   return {
     props: {
       collectible,

--- a/apps/web/src/pages/nft/[assetId]/sell.tsx
+++ b/apps/web/src/pages/nft/[assetId]/sell.tsx
@@ -1,0 +1,231 @@
+import { CollectibleWithDetails } from '@algomart/schemas'
+import { USD } from '@dinero.js/currencies'
+import { convert, dinero, Rates, toFormat } from 'dinero.js'
+import { GetServerSideProps } from 'next'
+import { FormEvent, useCallback, useState } from 'react'
+import useSWR from 'swr'
+import {
+  exact,
+  ExtractError,
+  integer,
+  max,
+  min,
+  number,
+  object,
+  required,
+  string,
+} from 'validator-fns'
+
+import css from '@/components/wallet-transfers/wallet-transfers.module.css'
+
+import { ApiClient } from '@/clients/api-client'
+import Button from '@/components/button'
+import LinkButton from '@/components/link-button'
+import PassphraseInput from '@/components/passphrase-input/passphrase-input'
+import CardPurchaseHeader from '@/components/purchase-form/cards/sections/card-header'
+import TextInput from '@/components/text-input/text-input'
+import { Environment } from '@/environment'
+import DefaultLayout from '@/layouts/default-layout'
+import { ALGO, formatALGO } from '@/utils/format-currency'
+import { urls } from '@/utils/urls'
+
+// Minimum reserve price is 1 ALGO (0.0000001 ALGO)
+const minReservePrice = 1
+// The current supply is 10 billion ALGO https://algorand.foundation/faq#supply-
+// To ensure correct behavior we're limiting the reserve price to 5 billion ALGO
+const maxReservePrice = 5_000_000_000
+
+const validateForm = async (values: Record<string, unknown>) => {
+  const validate = object({
+    passphrase: string(
+      exact(6, 'Passphrase must be six characters.'),
+      required('Passphrase is required.')
+    ),
+    reservePrice: number(
+      min(minReservePrice, 'Reserve price must be one or greater.'),
+      max(
+        maxReservePrice,
+        'Reserve price must be less than 1,000,000,000,000.'
+      ),
+      integer('Reserve price must be a whole number.'),
+      required('Reserve price is required.')
+    ),
+  })
+
+  return await validate(values)
+}
+
+const toDineroRates = (
+  coinbaseRates: Record<string, string>
+): Rates<number> => {
+  return Object.fromEntries(
+    Object.entries(coinbaseRates).map(([code, value]) => {
+      return [
+        code,
+        {
+          amount: Math.floor(Number(value) * 1e6),
+          scale: 6,
+        },
+      ]
+    })
+  )
+}
+
+const convertAlgoToCurrency = (
+  algo: number,
+  rates: Rates<number>,
+  locale?: string
+) => {
+  return toFormat(
+    convert(dinero({ amount: algo, currency: ALGO }), USD, rates),
+    ({ amount, currency }) =>
+      amount.toLocaleString('en-US', {
+        style: 'currency',
+        currency: currency.code,
+      })
+  )
+}
+
+export default function SellNFTPage({
+  collectible,
+}: {
+  collectible: CollectibleWithDetails
+}) {
+  const [values, setValues] = useState<{
+    passphrase: string
+    reservePrice: number | string
+  }>({ passphrase: '', reservePrice: 1 })
+  const { data } = useSWR(
+    `https://api.coinbase.com/v2/exchange-rates?currency=ALGO`
+  )
+
+  const [errors, setErrors] = useState<ExtractError<typeof validateForm>>({})
+  const displayReservePrice =
+    typeof values.reservePrice !== 'number' || Number.isNaN(values.reservePrice)
+      ? 0
+      : values.reservePrice * 1_000_000
+
+  const createAuction = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      setErrors({})
+      const result = await validateForm(values)
+
+      if (result.state === 'valid') {
+        console.log(result.value)
+      } else {
+        setErrors(result.errors)
+      }
+    },
+    [values]
+  )
+
+  return (
+    <DefaultLayout panelPadding pageTitle="Sell NFT">
+      <div className={css.root}>
+        <CardPurchaseHeader
+          image={collectible.image}
+          title={collectible.title}
+          subtitle={collectible.collection?.name}
+        />
+
+        <div className="mb-12 space-y-4 text-sm leading-6 text-left text-base-textSecondary">
+          <p>
+            This will create an smart contract auction where the highest bidder
+            will receive the NFT and your <strong>custodial wallet</strong> will
+            receive the bid amount. You can then transfer the ALGOs to your
+            non-custodial wallet.
+          </p>
+          <p>
+            The auction goes live about five minutes after its creation and
+            lasts for 72 hours. If no bids meet the reserve price then the NFT
+            is returned to you and any invalid bids are returned to the bidders.
+            You also have the option to cancel the auction before the five
+            minute countdown.
+          </p>
+          <p>
+            A 5% fee based on the final sale price is paid to the marketplace
+            for all sales.
+          </p>
+        </div>
+
+        <form onSubmit={createAuction} noValidate>
+          <input type="hidden" name="collectibleId" value={collectible.id} />
+          <div>
+            <PassphraseInput
+              id="passphrase"
+              label="Passphrase"
+              helpText="Unlock your custodial wallet."
+              error={errors.passphrase as string}
+              value={values.passphrase}
+              handleChange={(value) =>
+                setValues((previous) => ({ ...previous, passphrase: value }))
+              }
+            />
+          </div>
+          <div className="mt-6">
+            <TextInput
+              id="reservePrice"
+              name="reservePrice"
+              label="Reserve Price"
+              helpText="The minimum accepted bid in ALGO."
+              value={values.reservePrice}
+              error={errors.reservePrice as string}
+              onInput={({ currentTarget: { value } }) => {
+                const reservePrice = Math.min(
+                  Number.parseInt(value, 10),
+                  maxReservePrice
+                )
+                setValues((previous) => ({
+                  ...previous,
+                  reservePrice: Number.isNaN(reservePrice)
+                    ? value
+                    : reservePrice,
+                }))
+              }}
+            />
+            <div className="mt-2 text-sm text-base-textTertiary">
+              {formatALGO(displayReservePrice, 'en-US')}
+              {' currently equals about '}
+              {convertAlgoToCurrency(
+                displayReservePrice,
+                toDineroRates(data?.data?.rates ?? {}),
+                'en-US'
+              )}
+            </div>
+          </div>
+          <div className="flex flex-col mt-12">
+            <Button fullWidth type="submit">
+              Create auction
+            </Button>
+            <LinkButton
+              fullWidth
+              variant="tertiary"
+              href={urls.nft.replace(':assetId', String(collectible.address))}
+            >
+              Cancel
+            </LinkButton>
+          </div>
+        </form>
+      </div>
+    </DefaultLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  if (!Environment.isMarketplaceEnabled) {
+    return {
+      notFound: true,
+    }
+  }
+
+  const { assetId } = context.query
+  const collectible = await ApiClient.instance.getCollectible({
+    assetId: Number(assetId),
+  })
+  return {
+    props: {
+      collectible,
+    },
+  }
+}

--- a/apps/web/src/pages/nft/[assetId]/transfer.tsx
+++ b/apps/web/src/pages/nft/[assetId]/transfer.tsx
@@ -95,6 +95,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const collectible = await ApiClient.instance.getCollectible({
     assetId: Number(assetId),
   })
+
+  if (!collectible) {
+    return {
+      notFound: true,
+    }
+  }
+
   return {
     props: {
       collectible,

--- a/apps/web/src/templates/nft-template.tsx
+++ b/apps/web/src/templates/nft-template.tsx
@@ -69,11 +69,19 @@ export default function NFTTemplate({
 
         {userAddress && isTransferrable ? (
           <div className={css.panelActions}>
-            {/* TODO: enable this for secondary marketplace */}
             <ButtonGroup>
-              <LinkButton group="left" size="small" disabled href={urls.home}>
-                {t('nft:actions.sellNFT')}
-              </LinkButton>
+              {Environment.isMarketplaceEnabled ? (
+                <LinkButton
+                  group="left"
+                  size="small"
+                  href={urls.nftSell.replace(
+                    ':assetId',
+                    String(collectible.address)
+                  )}
+                >
+                  {t('nft:actions.sellNFT')}
+                </LinkButton>
+              ) : null}
               <LinkButton
                 group="right"
                 href={urls.nftTransfer.replace(

--- a/apps/web/src/utils/format-currency.ts
+++ b/apps/web/src/utils/format-currency.ts
@@ -30,18 +30,8 @@ export function formatALGO(value?: number | null, locale = DEFAULT_LOCALE) {
   )
 }
 
-export function formatCurrency(
-  value?: string | number | null,
-  locale = DEFAULT_LOCALE
-) {
-  let amount = value
-  if (amount === null || amount === undefined) {
-    amount = 0
-  } else if (typeof amount === 'string') {
-    amount = Math.round(Number.parseFloat(amount) * 100)
-  }
-
-  function transformer({
+export function createTransformer(locale = DEFAULT_LOCALE) {
+  return function transformer({
     amount,
     currency,
   }: {
@@ -53,8 +43,20 @@ export function formatCurrency(
       currency: currency.code,
     })
   }
+}
 
-  return toFormat(dinero({ amount, currency }), transformer)
+export function formatCurrency(
+  value?: string | number | null,
+  locale = DEFAULT_LOCALE
+) {
+  let amount = value
+  if (amount === null || amount === undefined) {
+    amount = 0
+  } else if (typeof amount === 'string') {
+    amount = Math.round(Number.parseFloat(amount) * 100)
+  }
+
+  return toFormat(dinero({ amount, currency }), createTransformer(locale))
 }
 
 export function formatToDecimal(amount: number, decimalPlaces: number) {

--- a/apps/web/src/utils/format-currency.ts
+++ b/apps/web/src/utils/format-currency.ts
@@ -13,6 +13,23 @@ import { Environment } from '@/environment'
 
 export const currency: Currency<number> = Environment.currency
 
+export const ALGO: Currency<number> = {
+  base: 10,
+  code: 'ALGO',
+  exponent: 6,
+}
+
+export function formatALGO(value?: number | null, locale = DEFAULT_LOCALE) {
+  return toFormat(
+    dinero({ amount: value, currency: ALGO }),
+    ({ amount, currency }) =>
+      `${amount.toLocaleString(locale, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: currency.exponent,
+      })} ${currency.code}`
+  )
+}
+
 export function formatCurrency(
   value?: string | number | null,
   locale = DEFAULT_LOCALE

--- a/apps/web/src/utils/logger.ts
+++ b/apps/web/src/utils/logger.ts
@@ -36,9 +36,6 @@ export const logger = pino({
         level: number,
       }
     },
-    log(message) {
-      return { message }
-    },
   },
   serializers: {
     ...pino.stdSerializers,

--- a/apps/web/src/utils/urls.ts
+++ b/apps/web/src/utils/urls.ts
@@ -20,6 +20,7 @@ export const urls = {
   myShowcase: '/my/showcase',
   nft: '/nft/:assetId',
   nftTransfer: '/nft/:assetId/transfer',
+  nftSell: '/nft/:assetId/sell',
   packOpening: '/pack-opening/:packId',
   paymentFailure: '/payments/failure',
   paymentSuccess: '/payments/success',

--- a/libs/schemas/src/auctions.ts
+++ b/libs/schemas/src/auctions.ts
@@ -9,8 +9,7 @@ export const CreateAuctionBodySchema = Type.Intersect([
   Type.Object({
     collectibleId: Type.String({ format: 'uuid' }),
     reservePrice: Type.Integer({ minimum: 0 }),
-    startAt: Type.String({ format: 'date-time' }),
-    endAt: Type.String({ format: 'date-time' }),
+    durationInHours: Type.Integer({ minimum: 1 }),
   }),
 ])
 

--- a/libs/schemas/src/auctions.ts
+++ b/libs/schemas/src/auctions.ts
@@ -1,11 +1,11 @@
 import { Static, Type } from '@sinclair/typebox'
 
 import { PassphraseSchema } from './accounts'
+import { CollectibleAuctionStatus } from './collectibles'
 import { ExternalIdSchema, Simplify } from './shared'
 
 export const CreateAuctionBodySchema = Type.Intersect([
   ExternalIdSchema,
-  PassphraseSchema,
   Type.Object({
     collectibleId: Type.String({ format: 'uuid' }),
     reservePrice: Type.Integer({ minimum: 0 }),
@@ -13,4 +13,34 @@ export const CreateAuctionBodySchema = Type.Intersect([
   }),
 ])
 
+export const CreateAuctionResponseSchema = Type.Object({
+  auctionId: Type.String({ format: 'uuid' }),
+  collectibleId: Type.String({ format: 'uuid' }),
+  status: Type.Enum(CollectibleAuctionStatus),
+  startAt: Type.String({ format: 'date-time' }),
+  endAt: Type.String({ format: 'date-time' }),
+  transactionId: Type.String(),
+})
+
+export const SetupAuctionBodySchema = Type.Intersect([
+  ExternalIdSchema,
+  PassphraseSchema,
+  Type.Object({
+    auctionId: Type.String({ format: 'uuid' }),
+  }),
+])
+
+export const SetupAuctionResponseSchema = Type.Object({
+  auctionId: Type.String({ format: 'uuid' }),
+  status: Type.Enum(CollectibleAuctionStatus),
+  transactionIds: Type.Array(Type.String()),
+})
+
 export type CreateAuctionBody = Simplify<Static<typeof CreateAuctionBodySchema>>
+export type CreateAuctionResponse = Simplify<
+  Static<typeof CreateAuctionResponseSchema>
+>
+export type SetupAuctionBody = Simplify<Static<typeof SetupAuctionBodySchema>>
+export type SetupAuctionResponse = Simplify<
+  Static<typeof SetupAuctionResponseSchema>
+>

--- a/libs/schemas/src/collectibles.ts
+++ b/libs/schemas/src/collectibles.ts
@@ -17,11 +17,19 @@ export enum IPFSStatus {
 }
 
 export enum CollectibleAuctionStatus {
+  // Prior to having an app ID set
   New = 'new',
+  // After having app ID set, but before auction is setup
+  Created = 'created',
+  // After setup is called, but before auction starts
   SettingUp = 'setting-up',
+  // Auction is live
   Active = 'active',
+  // Auction is over, but not yet settled
   Closing = 'closing',
+  // Auction is over and settled
   Closed = 'closed',
+  // Auction was canceled
   Canceled = 'canceled',
 }
 

--- a/libs/schemas/src/events.ts
+++ b/libs/schemas/src/events.ts
@@ -14,6 +14,7 @@ export enum EventEntityType {
   AlgorandTransactionGroup = 'algorand-transaction-group',
   Bid = 'bid',
   Collectible = 'collectible',
+  CollectibleAuction = 'collectible-auction',
   CollectibleOwnership = 'collectible-ownership',
   CollectibleShowcase = 'collectible-showcase',
   Notification = 'notification',

--- a/libs/shared/adapters/src/lib/algorand-adapter.ts
+++ b/libs/shared/adapters/src/lib/algorand-adapter.ts
@@ -516,7 +516,6 @@ export class AlgorandAdapter {
     lease?: Uint8Array
     note?: Uint8Array
     rekeyTo?: string
-    from?: string
   }) {
     const suggestedParams = await this.algod.getTransactionParams().do()
 
@@ -524,7 +523,7 @@ export class AlgorandAdapter {
       suggestedParams,
       approvalProgram: options.approvalProgram,
       clearProgram: options.clearProgram,
-      from: options.from || this.fundingAccount.addr,
+      from: this.fundingAccount.addr,
       numGlobalByteSlices: options.numGlobalByteSlices || 0,
       numGlobalInts: options.numGlobalInts || 0,
       numLocalByteSlices: options.numLocalByteSlices || 0,
@@ -540,24 +539,25 @@ export class AlgorandAdapter {
       rekeyTo: options.rekeyTo,
     })
 
-    return txn
+    return {
+      transaction: txn,
+      signedTransaction: txn.signTxn(this.fundingAccount.sk),
+    }
   }
 
-  appMinBalance(options: {
+  appMinBalance({
+    extraPages = 0,
+    numGlobalByteSlices: numberGlobalByteSlices = 0,
+    numGlobalInts: numberGlobalInts = 0,
+    numLocalByteSlices: numberLocalByteSlices = 0,
+    numLocalInts: numberLocalInts = 0,
+  }: {
     extraPages?: number
     numGlobalByteSlices?: number
     numGlobalInts?: number
     numLocalByteSlices?: number
     numLocalInts?: number
   }): { create: number; optIn: number } {
-    const {
-      extraPages = 0,
-      numGlobalByteSlices: numberGlobalByteSlices = 0,
-      numGlobalInts: numberGlobalInts = 0,
-      numLocalByteSlices: numberLocalByteSlices = 0,
-      numLocalInts: numberLocalInts = 0,
-    } = options
-
     // https://developer.algorand.org/docs/get-details/dapps/smart-contracts/apps/#minimum-balance-requirement-for-a-smart-contract
 
     return {

--- a/libs/shared/models/src/lib/collectible-auction.model.ts
+++ b/libs/shared/models/src/lib/collectible-auction.model.ts
@@ -21,11 +21,13 @@ export class CollectibleAuctionModel extends BaseModel {
   startAt!: string
   status!: CollectibleAuctionStatus
   transactionId!: string
+  setupTransactionId!: string | null
   userAccountId!: string
 
   bids?: CollectibleAuctionBidModel[]
   collectible?: CollectibleModel
   transaction?: AlgorandTransactionModel
+  setupTransaction?: AlgorandTransactionModel
   userAccount?: UserAccountModel
 
   static relationMappings = () => ({
@@ -42,6 +44,14 @@ export class CollectibleAuctionModel extends BaseModel {
       modelClass: AlgorandTransactionModel,
       join: {
         from: 'CollectibleAuction.transactionId',
+        to: 'AlgorandTransaction.id',
+      },
+    },
+    setupTransaction: {
+      relation: Model.BelongsToOneRelation,
+      modelClass: AlgorandTransactionModel,
+      join: {
+        from: 'CollectibleAuction.setupTransaction',
         to: 'AlgorandTransaction.id',
       },
     },

--- a/libs/shared/models/src/lib/collectible-auction.model.ts
+++ b/libs/shared/models/src/lib/collectible-auction.model.ts
@@ -14,7 +14,7 @@ export class CollectibleAuctionModel extends BaseModel {
   static tableName = 'CollectibleAuction'
   static jsonSchema = CollectibleAuctionSchema
 
-  appId!: number
+  appId!: number | null
   collectibleId!: string
   endAt!: string
   reservePrice!: number

--- a/libs/shared/services/src/lib/auctions.service.ts
+++ b/libs/shared/services/src/lib/auctions.service.ts
@@ -1,12 +1,23 @@
-import pino from 'pino'
-import { CreateAuctionBody } from '@algomart/schemas'
+import {
+  AlgorandTransactionStatus,
+  CollectibleAuctionStatus,
+  CreateAuctionBody,
+  EventAction,
+  EventEntityType,
+} from '@algomart/schemas'
 import { AlgorandAdapter } from '@algomart/shared/adapters'
-import { CollectibleModel, UserAccountModel } from '@algomart/shared/models'
-import { decrypt, userInvariant } from '@algomart/shared/utils'
+import {
+  CollectibleAuctionModel,
+  CollectibleModel,
+  EventModel,
+  UserAccountModel,
+} from '@algomart/shared/models'
+import { invariant, userInvariant } from '@algomart/shared/utils'
 import algosdk from 'algosdk'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { Transaction } from 'objection'
+import pino from 'pino'
 
 export class AuctionsService {
   logger: pino.Logger<unknown>
@@ -20,9 +31,18 @@ export class AuctionsService {
 
   async createAuction(
     request: CreateAuctionBody,
-    appSecret: string,
+    feePercentage: number,
     trx?: Transaction
   ) {
+    invariant(
+      feePercentage >= 0,
+      'feePercentage must be greater than or equal to 0'
+    )
+    invariant(
+      feePercentage <= 100,
+      'feePercentage must be less than or equal to 100'
+    )
+
     const user = await UserAccountModel.query(trx)
       .where({
         externalId: request.externalId,
@@ -30,25 +50,33 @@ export class AuctionsService {
       .withGraphJoined('algorandAccount')
       .first()
     userInvariant(user, 'User not found', 404)
-    const mnemonic = decrypt(
-      user.algorandAccount?.encryptedKey,
-      request.passphrase,
-      appSecret
-    )
-    userInvariant(mnemonic, 'Invalid passphrase', 400)
+    invariant(user.algorandAccount, `User ${user.id} has no Algorand account`)
 
     const collectible = await CollectibleModel.query(trx)
-      .where({
-        id: request.collectibleId,
-        ownerId: user.id,
-      })
+      .where('id', request.collectibleId)
+      .whereNotNull('address')
       .first()
     userInvariant(collectible, 'Collectible not found', 404)
 
-    this.logger.info({
-      collectible,
-      user,
-    })
+    const accountInfo = await this.algorand.getAccountInfo(
+      user.algorandAccount.address
+    )
+    invariant(
+      accountInfo,
+      `Algorand account info not found for ${user.algorandAccount.address}`
+    )
+    const asset = accountInfo.assets.find(
+      (asset) => asset.assetId === collectible.address
+    )
+    userInvariant(
+      asset,
+      `Asset ${collectible.address} not owned by ${user.algorandAccount.address}`,
+      400
+    )
+
+    this.logger.info(
+      `Creating auction for ${user.algorandAccount.address} with NFT ${asset.assetId}...`
+    )
 
     const approvalProgramBytes = await this.algorand.compileContract(
       await fs.readFile(
@@ -64,46 +92,83 @@ export class AuctionsService {
       )
     )
 
-    const txnFee = 1000
+    // Contract requires 2 global byte slices (strings) and 8 global uints
     const numberGlobalByteSlices = 2
-    const numberGlobalInts = 7
-    const accountInfo = await this.algorand.getAccountInfo(
-      user.algorandAccount?.address
-    )
-    const minBalance =
-      txnFee +
-      this.algorand.getAccountMinBalance(accountInfo) +
-      this.algorand.appMinBalance({
-        numGlobalByteSlices: numberGlobalByteSlices,
-        numGlobalInts: numberGlobalInts,
-      }).create
+    const numberGlobalInts = 8
 
+    // Set min bid increase to 1% of reserve price
+    const minBidPriceIncrease = Math.floor(request.reservePrice / 100)
+
+    // Start auction in five minutes
+    const startAt = Math.floor(Date.now() / 1000) + 5 * 60
+    const startAtDate = new Date(startAt * 1000)
+    const endAt =
+      Math.floor(Date.now() / 1000) + request.durationInHours * 60 * 60
+    const endAtDate = new Date(endAt * 1000)
     userInvariant(
-      accountInfo.amount >= minBalance,
-      `Insufficient balance, need ${minBalance}, has ${accountInfo.amount}`,
+      startAt < endAt,
+      'Auction end time must be after start time',
       400
     )
 
-    const txn = await this.algorand.createApplicationTransaction({
-      appArgs: [
-        algosdk.decodeAddress(user.algorandAccount?.address).publicKey,
-        algosdk.encodeUint64(collectible.address),
-        algosdk.encodeUint64(
-          Math.floor(new Date(request.startAt).getTime() / 1000)
-        ),
-        algosdk.encodeUint64(
-          Math.floor(new Date(request.endAt).getTime() / 1000)
-        ),
-        algosdk.encodeUint64(request.reservePrice),
-      ],
-      approvalProgram: approvalProgramBytes,
-      clearProgram: clearStateProgramBytes,
-      numGlobalByteSlices: numberGlobalByteSlices,
-      numGlobalInts: numberGlobalInts,
+    const { transaction, signedTransaction } =
+      await this.algorand.createApplicationTransaction({
+        appArgs: [
+          algosdk.decodeAddress(user.algorandAccount.address).publicKey,
+          algosdk.encodeUint64(collectible.address),
+          algosdk.encodeUint64(startAt),
+          algosdk.encodeUint64(endAt),
+          algosdk.encodeUint64(request.reservePrice),
+          algosdk.encodeUint64(minBidPriceIncrease),
+          algosdk.encodeUint64(Math.round(feePercentage)),
+        ],
+        approvalProgram: approvalProgramBytes,
+        clearProgram: clearStateProgramBytes,
+        numGlobalByteSlices: numberGlobalByteSlices,
+        numGlobalInts: numberGlobalInts,
+      })
+
+    await this.algorand.submitTransaction(signedTransaction)
+
+    const auction = await CollectibleAuctionModel.query(trx).insertGraph({
+      appId: null,
+      collectibleId: collectible.id,
+      endAt: endAtDate.toISOString(),
+      startAt: startAtDate.toISOString(),
+      reservePrice: request.reservePrice,
+      status: CollectibleAuctionStatus.New,
+      transaction: {
+        address: transaction.txID(),
+        status: AlgorandTransactionStatus.Pending,
+      },
+      userAccountId: user.id,
     })
 
-    this.logger.info({ txn }, 'transaction')
+    await EventModel.query(trx).insert({
+      action: EventAction.Create,
+      entityId: auction.id,
+      entityType: EventEntityType.CollectibleAuction,
+      userAccountId: user.id,
+    })
 
-    // TODO: submit transaction and then fund the app (escrow account) somehow?
+    return {
+      auctionId: auction.id,
+      collectibleId: collectible.id,
+      status: auction.status,
+      startAt: startAtDate,
+      endAtDate: endAtDate,
+    }
+  }
+
+  async setupAuction(trx?: Transaction) {
+    throw new Error('Not yet implemented')
+    // TODO: call setup method on the auction
+    // Requires:
+    // - auction's id so the right auction can be found
+    // - user's passphrase to sign asset transfer transaction (transferring to escrow account)
+    // - auction.appId to be set (this should be set by the transaction background task)
+    // - funding account funds to cover escrow account min balance (204,000 microAlgos)
+    // - funding account min balance will be increased by around 1 ALGO
+    // - must be called before the auction's start time
   }
 }

--- a/libs/shared/utils/src/lib/logger.ts
+++ b/libs/shared/utils/src/lib/logger.ts
@@ -41,9 +41,6 @@ export const createLogger = (logLevel: string, env: string) => {
           level: number,
         }
       },
-      log(message) {
-        return { message }
-      },
     },
     serializers: {
       ...pino.stdSerializers,


### PR DESCRIPTION
- [x] Adds new sell NFT page (fields will include: reserve price, duration, and wallet passphrase)
- [x] Adds API endpoints to create/setup smart contract auction
- [x] Updates txn confirm task to handle auction app statuses
- [ ] Updates/adds collectible status reflecting it's currently for sale (to avoid creating duplicate concurrent auctions)
- [ ] Checks that the collectible is eligible for sale (i.e. X days have passed since initial CC purchase and that ASA is not frozen)

For separate PRs:

- Auction cancellation
- Bidding flow
- Background task to close expired auctions
- Listing of NFTs that are for sale in secondary marketplace