### PR TITLE
Wire amount formatting; winning bidder fix; media gallery fixes

### DIFF
--- a/apps/web/languages/en-US/common.json
+++ b/apps/web/languages/en-US/common.json
@@ -60,7 +60,8 @@
     "View My Collection": "View My Collection",
     "View On AlgoExplorer": "View on AlgoExplorer",
     "View Release": "View Release",
-    "View Set": "View Set"
+    "View Set": "View Set",
+    "View image X of Y":"View image X of Y"
   },
   "dateTime": {
     "Days_one": "Day",
@@ -169,6 +170,7 @@
     "Collected": "Collected",
     "Checking for Payment": "Checking for Payment",
     "Connected to Wallet": "Connected to Wallet",
+    "Cover Image": "Cover Image",
     "Creating Payment": "Creating Payment",
     "Free": "Free",
     "I don’t have a code": "I don’t have a code",

--- a/apps/web/languages/en-US/common.json
+++ b/apps/web/languages/en-US/common.json
@@ -61,7 +61,7 @@
     "View On AlgoExplorer": "View on AlgoExplorer",
     "View Release": "View Release",
     "View Set": "View Set",
-    "View image X of Y":"View image X of Y"
+    "View image X of Y":"View image {{x}} of {{y}}"
   },
   "dateTime": {
     "Days_one": "Day",

--- a/apps/web/src/components/featured-pack/featured-pack.tsx
+++ b/apps/web/src/components/featured-pack/featured-pack.tsx
@@ -73,7 +73,7 @@ export default function HomeTemplate({
         {/* Image */}
         <div className={css.featuredImage}>
           <Image
-            src={featuredPack.image}
+            src={`${featuredPack.image}?width=1280&quality=75`}
             width={512}
             height={512}
             layout="responsive"

--- a/apps/web/src/components/featured-pack/featured-pack.tsx
+++ b/apps/web/src/components/featured-pack/featured-pack.tsx
@@ -73,12 +73,13 @@ export default function HomeTemplate({
         {/* Image */}
         <div className={css.featuredImage}>
           <Image
-            src={`${featuredPack.image}?width=1280&quality=75`}
+            src={featuredPack.image}
             width={512}
             height={512}
+            sizes="(max-width: 639px) 100vw, (max-width: 767px) calc(100vw * 1/2), (min-width: 768px) calc(100vw * 3/5)"
             layout="responsive"
             objectFit="cover"
-            alt={featuredPack.title}
+            alt={t('common:statuses.Cover Image')}
             priority
           />
         </div>

--- a/apps/web/src/components/media-gallery/media-gallery.tsx
+++ b/apps/web/src/components/media-gallery/media-gallery.tsx
@@ -76,7 +76,7 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
               alt={t('common:statuses.Selected Image')}
               className={css.contain}
               layout="fill"
-              src={currentMedia}
+              src={`${currentMedia}?width=1400&quality=75`}
               objectFit="cover"
               sizes="(min-width: 700px) 700px, 100vw"
               priority
@@ -103,10 +103,10 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
                 onClick={() => handleMediaChange(media)}
               >
                 <Image
-                  alt=""
+                  alt="media"
                   className={clsx(css.cover, css.fullWidth, css.rounded)}
                   layout="fill"
-                  src={media}
+                  src={`${media}?width=300`}
                   objectFit="cover"
                 />
               </button>

--- a/apps/web/src/components/media-gallery/media-gallery.tsx
+++ b/apps/web/src/components/media-gallery/media-gallery.tsx
@@ -76,7 +76,7 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
               alt={t('common:statuses.Selected Image')}
               className={css.contain}
               layout="fill"
-              src={`${currentMedia}?width=700&quality=95`}
+              src={currentMedia}
               objectFit="cover"
               sizes="(min-width: 700px) 700px, 100vw"
               priority
@@ -103,11 +103,12 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
                 onClick={() => handleMediaChange(media)}
               >
                 <Image
-                  alt="media"
+                  alt={t('common:actions.View image X of Y')}
                   className={clsx(css.cover, css.fullWidth, css.rounded)}
                   layout="fill"
-                  src={`${media}?width=300`}
+                  src={media}
                   objectFit="cover"
+                  sizes="25vw"
                 />
               </button>
             </li>

--- a/apps/web/src/components/media-gallery/media-gallery.tsx
+++ b/apps/web/src/components/media-gallery/media-gallery.tsx
@@ -21,8 +21,8 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
   const isSingularAsset = media.length === 1
 
   // Triggered when selecting a thumbnail
-  const handleMediaChange = (media: string) => {
-    setCurrentMedia(media)
+  const handleMediaChange = (medium: string) => {
+    setCurrentMedia(medium)
   }
 
   // Triggered when selecting the previous/next arrows
@@ -88,8 +88,8 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
       {/* Media thumbnails */}
       {!isSingularAsset && (
         <ul className={css.mediaListGrid}>
-          {media.map((media) => (
-            <li className={css.aspect} key={media}>
+          {media.map((medium, index) => (
+            <li className={css.aspect} key={medium}>
               <button
                 aria-label={t('common:actions.Select Image')}
                 className={clsx(
@@ -97,16 +97,19 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
                   css.overflowHidden,
                   css.mediaHyperlinkedWrapper,
                   {
-                    [css.opaque]: media === currentMedia,
+                    [css.opaque]: medium === currentMedia,
                   }
                 )}
-                onClick={() => handleMediaChange(media)}
+                onClick={() => handleMediaChange(medium)}
               >
                 <Image
-                  alt={t('common:actions.View image X of Y')}
+                  alt={t('common:actions.View image X of Y', {
+                    x: index + 1,
+                    y: media.length,
+                  })}
                   className={clsx(css.cover, css.fullWidth, css.rounded)}
                   layout="fill"
-                  src={media}
+                  src={medium}
                   objectFit="cover"
                   sizes="25vw"
                 />

--- a/apps/web/src/components/media-gallery/media-gallery.tsx
+++ b/apps/web/src/components/media-gallery/media-gallery.tsx
@@ -76,7 +76,7 @@ export default function MediaGallery({ media }: MediaGalleryProps) {
               alt={t('common:statuses.Selected Image')}
               className={css.contain}
               layout="fill"
-              src={`${currentMedia}?width=1400&quality=75`}
+              src={`${currentMedia}?width=700&quality=95`}
               objectFit="cover"
               sizes="(min-width: 700px) 700px, 100vw"
               priority

--- a/apps/web/src/pages/releases/[packSlug].tsx
+++ b/apps/web/src/pages/releases/[packSlug].tsx
@@ -135,7 +135,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       )
       const hasBids = bids?.some((b) => b.externalId === user.externalId)
       const isReserveMet = packTemplate.price <= activeBid?.amount
-      isHighestBidder = activeBid?.externalId === user.externalId && !isClosed
+      isHighestBidder = activeBid?.externalId === user.externalId
       isOwner = user && ownerExternalId === user.externalId ? true : false
       isWinningBidder = isHighestBidder && isClosed && isReserveMet
       isOutbid = !isHighestBidder && hasBids && !isClosed

--- a/apps/web/src/pages/releases/[packSlug].tsx
+++ b/apps/web/src/pages/releases/[packSlug].tsx
@@ -134,11 +134,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         !isAfterNow(new Date(packTemplate.auctionUntil))
       )
       const hasBids = bids?.some((b) => b.externalId === user.externalId)
-
-      isHighestBidder = activeBid?.externalId === user.externalId
+      const isReserveMet = packTemplate.price <= activeBid?.amount
+      isHighestBidder = activeBid?.externalId === user.externalId && !isClosed
       isOwner = user && ownerExternalId === user.externalId ? true : false
-      isWinningBidder = isHighestBidder && isClosed
-      isOutbid = !isHighestBidder && hasBids
+      isWinningBidder = isHighestBidder && isClosed && isReserveMet
+      isOutbid = !isHighestBidder && hasBids && !isClosed
     }
   }
 

--- a/apps/web/src/templates/release-template.tsx
+++ b/apps/web/src/templates/release-template.tsx
@@ -106,6 +106,7 @@ export default function ReleaseTemplate({
     content: string
     color: 'red' | 'blue' | 'green'
   } | null => {
+    if (isEnded) return null
     if (isWinningBidder) {
       return { content: `${t('release:You won the auction')}!`, color: 'green' }
     } else if (isHighestBidder) {


### PR DESCRIPTION
`git cherry-pick`'d a bucket-list of items. Need to verify some of the image stuff in the morning, seems some commit competition that's direction rather than syntax; so I'll check in on that & ping here when GTG.

New PR from `origin` instead of `lefnire` (https://github.com/deptagency/algomart/pull/371)