### PR TITLE
Configure static outbound IP for the API

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -179,6 +179,8 @@ jobs:
           TF_VAR_private_ip_name: ${{ secrets.PRIVATE_IP_NAME }}
           TF_VAR_vpc_name: ${{ secrets.VPC_NAME }}
           TF_VAR_vpc_access_connector_name: ${{ secrets.VPC_ACCESS_CONNECTOR_NAME }}
+          TF_VAR_vpc_cloud_router_name: ${{ secrets.VPC_CLOUD_ROUTER_NAME }}
+          TF_VAR_vpc_nat_name: ${{ secrets.VPC_NAT_NAME }}
           TF_VAR_web_service_name: ${{ secrets.WEB_SERVICE_NAME }}
 
           TF_VAR_api_database_name: ${{ secrets.API_DATABASE_NAME }}

--- a/terraform/cloud_run_api.tf
+++ b/terraform/cloud_run_api.tf
@@ -11,6 +11,8 @@ resource "google_cloud_run_service" "api" {
       annotations = {
         "run.googleapis.com/vpc-access-connector" = var.vpc_access_connector_name
 
+        "run.googleapis.com/vpc-access-egress" = "all"
+
         # BETA FEATURE
         #
         # Cloud Run by default will throttle CPU resources to near zero while a

--- a/terraform/nat_gateway.tf
+++ b/terraform/nat_gateway.tf
@@ -1,0 +1,21 @@
+resource "google_compute_router" "cloud_router" {
+  name    = var.vpc_cloud_router_name
+  network = google_compute_network.vpc.name
+  region  = var.region
+}
+
+resource "google_compute_address" "static" {
+  name         = var.public_outbound_ip_name
+  address_type = "EXTERNAL"
+  region       = var.region
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                   = var.vpc_nat_name
+  router                 = google_compute_router.cloud_router.name
+  region                 = google_compute_router.cloud_router.region
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = google_compute_address.static.*.self_link
+
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -311,3 +311,22 @@ variable "web_node_env" {
 variable "web_revision_name" {
   sensitive = true
 }
+
+##
+## VPC and networking
+##
+
+variable "public_outbound_ip_name" {
+  default   = "algomart-public-outbound-ip"
+  sensitive = true
+}
+
+variable "vpc_cloud_router_name" {
+  default = "algomart-cloud-router"
+  sensitive = true
+}
+
+variable "vpc_nat_name" {
+  default = "algomart-nat"
+  sensitive = true
+}


### PR DESCRIPTION
Ensures the API uses a static outbound API in GCP.