### PR TITLE
Themes & Bug fixes

### DIFF
--- a/apps/web/languages/en-US/common.json
+++ b/apps/web/languages/en-US/common.json
@@ -87,6 +87,7 @@
     "pageTitle": "AlgoMart",
     "pageDescription": "The best storefront for all your NFT assets",
     "rarityDefault": "Common",
+    "Theme": "Theme",
     "404": {
       "title": "Uh oh! There's nothing to see here.",
       "body": "<0>Unfortunately this page doesn't exist. Sorry about that! <1>Click here</1> to go home, or browse some of our <2>latest releases</2>.</0>"

--- a/apps/web/src/components/app-footer/sections/app-footer-currency.tsx
+++ b/apps/web/src/components/app-footer/sections/app-footer-currency.tsx
@@ -4,7 +4,6 @@ import useTranslation from 'next-translate/useTranslation'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Currency } from '@/components/auth-inputs/auth-inputs'
-import { SelectOption } from '@/components/select/select'
 import { useAuth } from '@/contexts/auth-context'
 import { useCurrency } from '@/hooks/use-currency'
 import { useLanguage } from '@/hooks/use-language'

--- a/apps/web/src/components/app-footer/sections/app-footer-currency.tsx
+++ b/apps/web/src/components/app-footer/sections/app-footer-currency.tsx
@@ -27,9 +27,7 @@ export default function AppFooterCurrency() {
 
   // callback to handle dropdown changes
   const handleDropdownCurrencyChange = useCallback(
-    async (selectedOption: SelectOption) => {
-      const currency = selectedOption?.id
-
+    async (currency: string) => {
       setLoading(true)
 
       // Validate form body
@@ -82,8 +80,7 @@ export default function AppFooterCurrency() {
       disabled={loading}
       showLabel={false}
       value={dropdownCurrency}
-      handleChange={handleDropdownCurrencyChange}
-      t={t}
+      onChange={handleDropdownCurrencyChange}
     />
   )
 }

--- a/apps/web/src/components/app-footer/sections/app-footer-language.tsx
+++ b/apps/web/src/components/app-footer/sections/app-footer-language.tsx
@@ -4,7 +4,6 @@ import useTranslation from 'next-translate/useTranslation'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Language } from '@/components/auth-inputs/auth-inputs'
-import { SelectOption } from '@/components/select/select'
 import { useAuth } from '@/contexts/auth-context'
 import { useLanguage } from '@/hooks/use-language'
 import { AuthService } from '@/services/auth-service'
@@ -25,9 +24,7 @@ export default function AppFooterLanguage() {
 
   // callback to handle dropdown changes
   const handleDropdownLanguageChange = useCallback(
-    async (selectedOption: SelectOption) => {
-      const language = selectedOption?.id
-
+    async (language: string) => {
       setLoading(true)
 
       // Validate form body
@@ -77,8 +74,7 @@ export default function AppFooterLanguage() {
       disabled={loading}
       showLabel={false}
       value={dropdownLanguage}
-      handleChange={handleDropdownLanguageChange}
-      t={t}
+      onChange={handleDropdownLanguageChange}
     />
   )
 }

--- a/apps/web/src/components/auth-inputs/auth-inputs.tsx
+++ b/apps/web/src/components/auth-inputs/auth-inputs.tsx
@@ -68,7 +68,6 @@ export function Currency({
     <FormField className={clsx({ [css.formField]: !className }, className)}>
       {options.length > 0 && (
         <Select
-          className="pl-8"
           error={error as string}
           disabled={disabled}
           label={showLabel ? t('forms:fields.currencies.label') : undefined}
@@ -142,7 +141,6 @@ export function Language({
     <FormField className={clsx({ [css.formField]: !className }, className)}>
       {options.length > 0 && (
         <Select
-          className="pl-8"
           error={error as string}
           disabled={disabled}
           label={showLabel ? t('forms:fields.languages.label') : undefined}
@@ -160,7 +158,6 @@ export function Username({ error }: AuthInputProps) {
   return (
     <FormField className={css.formField}>
       <TextInput
-        className="pl-8"
         error={error as string}
         helpText={t('forms:fields.username.helpText')}
         id="username"

--- a/apps/web/src/components/auth-inputs/auth-inputs.tsx
+++ b/apps/web/src/components/auth-inputs/auth-inputs.tsx
@@ -21,6 +21,8 @@ import FormField from '@/components/form-field'
 import PassphraseInput from '@/components/passphrase-input/passphrase-input'
 import TextInput from '@/components/text-input/text-input'
 import { useI18n } from '@/contexts/i18n-context'
+import { useCurrency } from '@/hooks/use-currency'
+import { useLanguage } from '@/hooks/use-language'
 import { FileWithPreview } from '@/types/file'
 
 /**
@@ -48,6 +50,7 @@ export function Currency({
   const [options, setOptions] = useState<SelectOption[]>([])
   const { currencyConversions } = useI18n()
   const { t } = useTranslation()
+  const currency = useCurrency()
 
   useEffect(() => {
     if (currencyConversions) {
@@ -59,7 +62,6 @@ export function Currency({
           key: targetCurrency,
           label: targetCurrency,
         }))
-
       setOptions(intersection)
     }
   }, [currencyConversions]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -68,6 +70,8 @@ export function Currency({
     <FormField className={clsx({ [css.formField]: !className }, className)}>
       {options.length > 0 && (
         <Select
+          name="currency"
+          defaultValue={currency}
           error={error as string}
           disabled={disabled}
           label={showLabel ? t('forms:fields.currencies.label') : undefined}
@@ -108,6 +112,7 @@ export function Language({
   const [options, setOptions] = useState<SelectOption[]>([])
   const { languages, getI18nInfo } = useI18n()
   const { t } = useTranslation()
+  const language = useLanguage()
 
   useEffect(() => {
     const run = async () => {
@@ -141,6 +146,8 @@ export function Language({
     <FormField className={clsx({ [css.formField]: !className }, className)}>
       {options.length > 0 && (
         <Select
+          name="language"
+          defaultValue={language}
           error={error as string}
           disabled={disabled}
           label={showLabel ? t('forms:fields.languages.label') : undefined}

--- a/apps/web/src/components/auth-inputs/auth-inputs.tsx
+++ b/apps/web/src/components/auth-inputs/auth-inputs.tsx
@@ -8,11 +8,11 @@ import {
 } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import Image from 'next/image'
-import { Translate } from 'next-translate'
+import useTranslation from 'next-translate/useTranslation'
 import React, { ReactNode, useEffect, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 
-import Select, { SelectOption } from '../select/select'
+import Select, { SelectOption } from '../select-input/select-input'
 
 import css from './auth-inputs.module.css'
 
@@ -31,9 +31,8 @@ export interface AuthInputProps {
   disabled?: boolean
   error?: string | unknown
   helpLink?: ReactNode
-  t: Translate
   className?: string
-  handleChange?(option: SelectOption): void
+  onChange?(value: string): void
   showLabel?: boolean
   value?: string
 }
@@ -41,15 +40,14 @@ export interface AuthInputProps {
 export function Currency({
   error,
   disabled,
-  handleChange,
+  onChange,
   showLabel = true,
-  t,
   value,
   className = '',
 }: AuthInputProps) {
   const [options, setOptions] = useState<SelectOption[]>([])
-  const [selectedValue, setSelectedValue] = useState<SelectOption>()
   const { currencyConversions } = useI18n()
+  const { t } = useTranslation()
 
   useEffect(() => {
     if (currencyConversions) {
@@ -58,7 +56,7 @@ export function Currency({
           Object.keys(currencyConversions).includes(dineroCurrencyKey)
         )
         .map((targetCurrency) => ({
-          id: targetCurrency,
+          key: targetCurrency,
           label: targetCurrency,
         }))
 
@@ -66,26 +64,17 @@ export function Currency({
     }
   }, [currencyConversions]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    setSelectedValue(
-      options && value ? options.find((option) => option.id === value) : null
-    )
-  }, [options, value])
-
   return (
     <FormField className={clsx({ [css.formField]: !className }, className)}>
       {options.length > 0 && (
         <Select
           className="pl-8"
-          defaultOption={options[0]}
           error={error as string}
           disabled={disabled}
           label={showLabel ? t('forms:fields.currencies.label') : undefined}
-          id="currency"
-          name="currency"
           options={options}
-          selectedValue={selectedValue}
-          handleChange={handleChange}
+          value={value}
+          onChange={onChange}
           Icon={<CurrencyDollarIcon />}
         />
       )}
@@ -93,7 +82,8 @@ export function Currency({
   )
 }
 
-export function Email({ error, t }: AuthInputProps) {
+export function Email({ error }: AuthInputProps) {
+  const { t } = useTranslation()
   return (
     <FormField className={css.formField}>
       <TextInput
@@ -111,15 +101,14 @@ export function Email({ error, t }: AuthInputProps) {
 export function Language({
   error,
   disabled,
-  handleChange,
+  onChange,
   showLabel = true,
-  t,
   value,
   className = '',
 }: AuthInputProps) {
   const [options, setOptions] = useState<SelectOption[]>([])
-  const [selectedValue, setSelectedValue] = useState<SelectOption>()
   const { languages, getI18nInfo } = useI18n()
+  const { t } = useTranslation()
 
   useEffect(() => {
     const run = async () => {
@@ -132,7 +121,7 @@ export function Language({
 
         setOptions(
           i18nStateLanguages.map((language) => ({
-            id: language.languages_code,
+            key: language.languages_code,
             label: language.label,
           }))
         )
@@ -140,7 +129,7 @@ export function Language({
         // if service fails, at least let them set English
         setOptions([
           {
-            id: DEFAULT_LANG,
+            key: DEFAULT_LANG,
             label: t('common:global.language'),
           },
         ])
@@ -149,33 +138,25 @@ export function Language({
     run()
   }, [t, languages]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    setSelectedValue(
-      options && value ? options.find((option) => option.id === value) : null
-    )
-  }, [options, value])
-
   return (
     <FormField className={clsx({ [css.formField]: !className }, className)}>
       {options.length > 0 && (
         <Select
           className="pl-8"
-          defaultOption={options[0]}
           error={error as string}
           disabled={disabled}
           label={showLabel ? t('forms:fields.languages.label') : undefined}
-          id="language"
-          name="language"
           options={options}
-          selectedValue={selectedValue}
-          handleChange={handleChange}
+          value={value}
+          onChange={onChange}
           Icon={<GlobeAltIcon />}
         />
       )}
     </FormField>
   )
 }
-export function Username({ error, t }: AuthInputProps) {
+export function Username({ error }: AuthInputProps) {
+  const { t } = useTranslation()
   return (
     <FormField className={css.formField}>
       <TextInput
@@ -193,7 +174,8 @@ export function Username({ error, t }: AuthInputProps) {
   )
 }
 
-export function Password({ error, helpLink, t }: AuthInputProps) {
+export function Password({ error, helpLink }: AuthInputProps) {
+  const { t } = useTranslation()
   return (
     <FormField className={css.formField}>
       <TextInput
@@ -225,8 +207,8 @@ export function ProfileImage({
   profilePic,
   showHelpText = true,
   showLabel = true,
-  t,
 }: ProfileImageProps) {
+  const { t } = useTranslation()
   const [dropError, setDropError] = useState<boolean>(false)
   const { getRootProps, getInputProps } = useDropzone({
     accept: 'image/*',
@@ -317,7 +299,8 @@ export function ProfileImage({
   )
 }
 
-export function Passphrase({ error, t }: AuthInputProps) {
+export function Passphrase({ error }: AuthInputProps) {
+  const { t } = useTranslation()
   return (
     <FormField className={css.formField}>
       <label htmlFor="passphrase" className={css.labelContainer}>
@@ -348,7 +331,8 @@ export function Passphrase({ error, t }: AuthInputProps) {
   )
 }
 
-export function Submit({ disabled, t }: AuthInputProps) {
+export function Submit({ disabled }: AuthInputProps) {
+  const { t } = useTranslation()
   return (
     <FormField>
       <Button disabled={disabled} fullWidth type="submit">

--- a/apps/web/src/components/profile/my-profile-currency.tsx
+++ b/apps/web/src/components/profile/my-profile-currency.tsx
@@ -10,7 +10,6 @@ import css from './my-profile-language.module.css'
 import { Currency } from '@/components/auth-inputs/auth-inputs'
 import Button from '@/components/button'
 import Heading from '@/components/heading'
-import { SelectOption } from '@/components/select/select'
 import { useAuth } from '@/contexts/auth-context'
 import { useCurrency } from '@/hooks/use-currency'
 import { AuthService } from '@/services/auth-service'
@@ -90,10 +89,6 @@ export default function MyProfileCurrency() {
     setIsEditing(false)
   }, [user])
 
-  const handleCurrencyChange = useCallback((selectOption: SelectOption) => {
-    setCurrency(selectOption.id as string)
-  }, [])
-
   return (
     <section className={common.section}>
       <div className={common.sectionHeader}>
@@ -118,8 +113,7 @@ export default function MyProfileCurrency() {
               disabled={!isEditing}
               showLabel={false}
               value={currency}
-              handleChange={handleCurrencyChange}
-              t={t}
+              onChange={setCurrency}
             />
             {isEditing ? (
               <>

--- a/apps/web/src/components/profile/my-profile-image.tsx
+++ b/apps/web/src/components/profile/my-profile-image.tsx
@@ -81,7 +81,6 @@ export default function MyProfileImage() {
           profilePic={profilePic}
           showHelpText={false}
           showLabel={false}
-          t={t}
         />
         <Button
           disabled={loading || !profilePicChanged}

--- a/apps/web/src/components/profile/my-profile-language.module.css
+++ b/apps/web/src/components/profile/my-profile-language.module.css
@@ -3,7 +3,7 @@
 }
 
 .inputWrapper > div {
-  @apply h-full py-3 ml-0 mb-0 flex-grow pt-0 pb-0;
+  @apply flex-grow h-full py-3 pt-0 pb-0 mb-0 ml-0;
 }
 
 .inputWrapper button {
@@ -15,11 +15,11 @@
 }
 
 .inputWrapper input[disabled] {
-  @apply text-opacity-50 bg-white shadow-none;
+  @apply text-opacity-50 shadow-none bg-base-bgCard;
 }
 
 .editButton {
-  @apply right-0 text-black underline;
+  @apply right-0 ml-4 underline text-base-textPrimary;
 }
 
 .cancelButton {

--- a/apps/web/src/components/profile/my-profile-language.tsx
+++ b/apps/web/src/components/profile/my-profile-language.tsx
@@ -10,7 +10,6 @@ import css from './my-profile-language.module.css'
 import { Language } from '@/components/auth-inputs/auth-inputs'
 import Button from '@/components/button'
 import Heading from '@/components/heading'
-import { SelectOption } from '@/components/select/select'
 import { useAuth } from '@/contexts/auth-context'
 import { useLanguage } from '@/hooks/use-language'
 import { AuthService } from '@/services/auth-service'
@@ -92,10 +91,6 @@ export default function MyProfileLanguage() {
     setIsEditing(false)
   }, [user])
 
-  const handleLanguageChange = useCallback((selectOption: SelectOption) => {
-    setFormLanguage(selectOption.id as string)
-  }, [])
-
   useEffect(() => {
     setFormLanguage(language)
   }, [language])
@@ -124,8 +119,7 @@ export default function MyProfileLanguage() {
               disabled={!isEditing}
               showLabel={false}
               value={formLanguage}
-              handleChange={handleLanguageChange}
-              t={t}
+              onChange={setFormLanguage}
             />
             {isEditing ? (
               <>

--- a/apps/web/src/components/profile/my-profile-nav.tsx
+++ b/apps/web/src/components/profile/my-profile-nav.tsx
@@ -8,11 +8,13 @@ import Button from '../button'
 import css from './my-profile-nav.module.css'
 
 import AppLink from '@/components/app-link/app-link'
-import Select, { SelectOption } from '@/components/select/select'
+import Select, { SelectOption } from '@/components/select-input/select-input'
 import { useAuth } from '@/contexts/auth-context'
 import { useRedemption } from '@/contexts/redemption-context'
 import useAdmin from '@/hooks/use-admin'
 import { urls } from '@/utils/urls'
+
+const LOG_OUT = 'LOG_OUT'
 
 interface ProfileNavProps {
   screen: 'desktop' | 'mobile'
@@ -25,16 +27,18 @@ export default function ProfileNav({ screen }: ProfileNavProps) {
   const { setRedeemable } = useRedemption()
   const { t } = useTranslation()
 
-  const getCurrentPage = useCallback(
-    (href: string) => {
-      return href === pathname || `${href}/add` === pathname
-    },
-    [pathname]
-  )
+  // const getCurrentPage = useCallback(
+  //   (href: string) => href === pathname || `${href}/add` === pathname,
+  //   [pathname]
+  // )
 
   const handleChange = useCallback(
-    (option: SelectOption) => {
-      push(option.id)
+    (value) => {
+      if (value === LOG_OUT) {
+        signOut()
+      } else {
+        push(value)
+      }
     },
     [push]
   )
@@ -46,24 +50,27 @@ export default function ProfileNav({ screen }: ProfileNavProps) {
   }, [auth, push, setRedeemable])
 
   const navItems = [
-    { id: urls.myProfile, label: t('common:pageTitles.My Profile') },
-    { id: urls.myProfileSecurity, label: t('common:pageTitles.Security') },
+    { key: urls.myProfile, label: t('common:pageTitles.My Profile') },
+    { key: urls.myProfileSecurity, label: t('common:pageTitles.Security') },
     {
-      id: urls.myProfilePaymentMethods,
+      key: urls.myProfilePaymentMethods,
       label: t('common:pageTitles.Payment Methods'),
     },
     {
-      id: urls.myProfileTransactions,
+      key: urls.myProfileTransactions,
       label: t('common:pageTitles.Transactions'),
     },
     {
-      id: urls.myProfileImportNFT,
+      key: urls.myProfileImportNFT,
       label: t('common:pageTitles.Import NFT'),
     },
   ] as SelectOption[]
 
   if (isAdmin) {
-    navItems.push({ id: urls.admin.index, label: t('common:pageTitles.Admin') })
+    navItems.push({
+      key: urls.admin.index,
+      label: t('common:pageTitles.Admin'),
+    })
   }
 
   return (
@@ -75,22 +82,28 @@ export default function ProfileNav({ screen }: ProfileNavProps) {
     >
       <div className={css.mobileWrapper}>
         <Select
-          handleChange={handleChange}
-          options={navItems}
-          selectedValue={navItems.find(({ id }) => getCurrentPage(id))}
+          onChange={handleChange}
+          options={[
+            ...navItems,
+            {
+              key: LOG_OUT,
+              label: t('common:actions.Sign Out'),
+            },
+          ]}
+          value={pathname.replace(/\/add$/, '')}
         />
       </div>
       <div className={css.desktopWrapper}>
         <ul className={css.listWrapper}>
-          {navItems.map(({ id, label }) => (
+          {navItems.map(({ key, label }) => (
             <li
               className={clsx(css.listItem, {
                 [css.listItemActive]:
-                  id === pathname || `${id}/add` === pathname,
+                  key === pathname || `${key}/add` === pathname,
               })}
-              key={id}
+              key={key}
             >
-              <AppLink href={id}>{label}</AppLink>
+              <AppLink href={key}>{label}</AppLink>
             </li>
           ))}
         </ul>

--- a/apps/web/src/components/profile/my-profile-nav.tsx
+++ b/apps/web/src/components/profile/my-profile-nav.tsx
@@ -27,11 +27,6 @@ export default function ProfileNav({ screen }: ProfileNavProps) {
   const { setRedeemable } = useRedemption()
   const { t } = useTranslation()
 
-  // const getCurrentPage = useCallback(
-  //   (href: string) => href === pathname || `${href}/add` === pathname,
-  //   [pathname]
-  // )
-
   const handleChange = useCallback(
     (value) => {
       if (value === LOG_OUT) {

--- a/apps/web/src/components/profile/my-profile-theme.tsx
+++ b/apps/web/src/components/profile/my-profile-theme.tsx
@@ -1,0 +1,37 @@
+import useTranslation from 'next-translate/useTranslation'
+
+import common from './my-profile-common.module.css'
+
+import Heading from '@/components/heading'
+import Select, { SelectOption } from '@/components/select-input/select-input'
+import { useThemeContext } from '@/contexts/theme-context'
+
+const OS_THEME = 'OS'
+
+const THEME_OPTIONS: SelectOption[] = [
+  { label: '🌑 Dark', key: 'dark' },
+  { label: '🌕 Light', key: 'light' },
+  { label: '🌗 OS Theme', key: OS_THEME },
+]
+
+export default function MyProfileCurrency() {
+  const { theme, setTheme } = useThemeContext()
+  const { t } = useTranslation()
+
+  return (
+    <section className={common.section}>
+      <div className={common.sectionHeader}>
+        <Heading className={common.sectionHeading} level={2}>
+          {t('common:global.Theme')}
+        </Heading>
+      </div>
+      <div className={common.sectionContent}>
+        <Select
+          value={theme ? theme : OS_THEME}
+          options={THEME_OPTIONS}
+          onChange={(theme) => setTheme(theme === OS_THEME ? null : theme)}
+        />
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/components/profile/my-profile-theme.tsx
+++ b/apps/web/src/components/profile/my-profile-theme.tsx
@@ -9,9 +9,30 @@ import { useThemeContext } from '@/contexts/theme-context'
 const OS_THEME = 'OS'
 
 const THEME_OPTIONS: SelectOption[] = [
-  { label: '🌑 Dark', key: 'dark' },
-  { label: '🌕 Light', key: 'light' },
-  { label: '🌗 OS Theme', key: OS_THEME },
+  {
+    label: (
+      <span>
+        <span aria-hidden="true">🌑 </span>Dark
+      </span>
+    ),
+    key: 'dark',
+  },
+  {
+    label: (
+      <span>
+        <span aria-hidden="true">🌕 </span>Light
+      </span>
+    ),
+    key: 'light',
+  },
+  {
+    label: (
+      <span>
+        <span aria-hidden="true">🌗 </span>OS Theme
+      </span>
+    ),
+    key: OS_THEME,
+  },
 ]
 
 export default function MyProfileCurrency() {

--- a/apps/web/src/components/select-input/select-input.tsx
+++ b/apps/web/src/components/select-input/select-input.tsx
@@ -23,7 +23,6 @@ export interface SelectProps
   options: SelectOption[]
   value?: string
   Icon?: ReactNode
-  fullWidth?: boolean
 }
 
 export default function Select({

--- a/apps/web/src/components/select-input/select-input.tsx
+++ b/apps/web/src/components/select-input/select-input.tsx
@@ -113,6 +113,7 @@ export default function Select({
       </Listbox>
       {/* Used to capture value of select */}
       <input
+        tabIndex={-1}
         className="sr-only"
         readOnly
         value={selectedOption.key}

--- a/apps/web/src/components/select-input/select-input.tsx
+++ b/apps/web/src/components/select-input/select-input.tsx
@@ -1,7 +1,13 @@
 import { Listbox } from '@headlessui/react'
 import { SelectorIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
-import { DetailedHTMLProps, InputHTMLAttributes, ReactNode } from 'react'
+import {
+  DetailedHTMLProps,
+  InputHTMLAttributes,
+  ReactNode,
+  useMemo,
+  useState,
+} from 'react'
 
 import css from './select.module.css'
 
@@ -26,18 +32,37 @@ export interface SelectProps
 }
 
 export default function Select({
+  defaultValue,
   disabled,
   error,
   onChange,
   helpText,
   id,
+  name,
   label,
   options,
   value,
   Icon,
 }: SelectProps) {
   const _id = id ?? crypto.randomUUID()
-  const selectedOption = options.find((option) => option.key === value)
+  const [internalValue, setInternalValue] = useState(
+    defaultValue || options[0].key
+  )
+
+  const actualValue = value ?? internalValue
+  const selectedOption = useMemo(() => {
+    return value
+      ? options.find((option) => option.key === value)
+      : options.find((option) => option.key === internalValue)
+  }, [options, internalValue, value])
+
+  const handleChange = (value: string) => {
+    if (onChange) {
+      onChange(value)
+    } else {
+      setInternalValue(value)
+    }
+  }
 
   return (
     <label className={css.root} data-input="select" htmlFor={_id}>
@@ -46,7 +71,7 @@ export default function Select({
         {error && <div className={css.errorText}>{error}</div>}
         {!error && helpText && <div className={css.helpText}>{helpText}</div>}
       </div>
-      <Listbox disabled={disabled} onChange={onChange} value={value}>
+      <Listbox disabled={disabled} onChange={handleChange} value={actualValue}>
         <div className={css.selectContainer}>
           <Listbox.Button
             className={clsx(css.selectButton, {
@@ -91,7 +116,7 @@ export default function Select({
         className="sr-only"
         readOnly
         value={selectedOption.key}
-        name={id}
+        name={name}
         id={id}
       />
     </label>

--- a/apps/web/src/components/select-input/select-input.tsx
+++ b/apps/web/src/components/select-input/select-input.tsx
@@ -1,0 +1,100 @@
+import { Listbox } from '@headlessui/react'
+import { SelectorIcon } from '@heroicons/react/outline'
+import clsx from 'clsx'
+import { DetailedHTMLProps, InputHTMLAttributes, ReactNode } from 'react'
+
+import css from './select.module.css'
+
+export interface SelectOption {
+  key: string
+  label: string | ReactNode
+  disabled?: boolean
+}
+
+export interface SelectProps
+  extends DetailedHTMLProps<
+    Omit<InputHTMLAttributes<HTMLSelectElement>, 'onChange'>,
+    HTMLSelectElement
+  > {
+  error?: string
+  onChange?(value: string): void
+  helpText?: string
+  label?: string
+  options: SelectOption[]
+  value?: string
+  Icon?: ReactNode
+  fullWidth?: boolean
+}
+
+export default function Select({
+  disabled,
+  error,
+  onChange,
+  helpText,
+  id,
+  label,
+  options,
+  value,
+  Icon,
+}: SelectProps) {
+  const _id = id ?? crypto.randomUUID()
+  const selectedOption = options.find((option) => option.key === value)
+
+  return (
+    <label className={css.root} data-input="select" htmlFor={_id}>
+      <div className={css.labelContainer}>
+        {label && <div className={css.label}>{label}</div>}
+        {error && <div className={css.errorText}>{error}</div>}
+        {!error && helpText && <div className={css.helpText}>{helpText}</div>}
+      </div>
+      <Listbox disabled={disabled} onChange={onChange} value={value}>
+        <div className={css.selectContainer}>
+          <Listbox.Button
+            className={clsx(css.selectButton, {
+              [css.selectButtonDisabled]: disabled,
+              [css.selectButtonError]: error,
+            })}
+          >
+            <div className={css.selectButtonText}>
+              {Icon}
+              {selectedOption.label}
+            </div>
+            <div className={css.selectButtonIconContainer}>
+              <SelectorIcon
+                className={css.selectButtonIcon}
+                aria-hidden="true"
+              />
+            </div>
+          </Listbox.Button>
+
+          <Listbox.Options className={css.selectOptions}>
+            {options.map((option) => (
+              <Listbox.Option
+                disabled={option.disabled}
+                className={({ active, selected }) =>
+                  clsx(css.selectOption, {
+                    [css.selectOptionActive]: active,
+                    [css.selectOptionSelected]: selected,
+                    [css.selectOptionDisabled]: option.disabled,
+                  })
+                }
+                key={option.key}
+                value={option.key}
+              >
+                {option.label}
+              </Listbox.Option>
+            ))}
+          </Listbox.Options>
+        </div>
+      </Listbox>
+      {/* Used to capture value of select */}
+      <input
+        className="sr-only"
+        readOnly
+        value={selectedOption.key}
+        name={id}
+        id={id}
+      />
+    </label>
+  )
+}

--- a/apps/web/src/components/select-input/select.module.css
+++ b/apps/web/src/components/select-input/select.module.css
@@ -1,0 +1,73 @@
+.root {
+  @apply relative block text-black;
+}
+
+.labelContainer {
+  @apply relative flex flex-wrap justify-between w-full font-bold text-base-textPrimary;
+}
+
+.label {
+  @apply w-1/2 mb-1;
+}
+
+.helpText {
+  @apply w-1/2 mt-1 text-xs font-light text-right text-base-gray-medium;
+}
+
+.errorText {
+  @apply text-xs font-light text-right text-base-error;
+}
+
+.selectContainer {
+  @apply relative;
+}
+
+.selectButton {
+  @apply relative w-full text-left bg-white border rounded-sm cursor-default text-base-gray-dark;
+  padding: 10px 50px 10px 10px;
+}
+
+.selectButtonDisabled {
+  @apply text-opacity-50 bg-base-bg border-base-bg dark:bg-white dark:bg-opacity-80;
+}
+
+.selectButtonError {
+  @apply border-base-error;
+}
+
+.selectButtonText {
+  @apply grid justify-start grid-flow-col grid-rows-1 gap-4 text-base truncate;
+}
+
+.selectButtonText svg {
+  @apply opacity-75 stroke-current justify-self-end;
+  width: 22px;
+}
+
+.selectButtonIconContainer {
+  @apply absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none;
+}
+
+.selectButtonIcon {
+  @apply w-5 h-5 text-gray-400;
+}
+
+.selectOptions {
+  @apply absolute z-10 w-full py-1 mt-1 overflow-auto text-sm bg-white border rounded-sm shadow-md max-h-60;
+}
+
+.selectOption {
+  @apply relative p-3 font-light cursor-default select-none;
+}
+
+.selectOptionActive {
+  @apply bg-action-secondary;
+}
+
+.selectOptionSelected {
+  @apply font-semibold bg-gray-200;
+}
+
+.selectOptionDisabled {
+  @apply text-base-textDisabled;
+}

--- a/apps/web/src/components/select/select.module.css
+++ b/apps/web/src/components/select/select.module.css
@@ -23,12 +23,12 @@
 }
 
 .selectButton {
-  @apply relative w-full text-left bg-white border rounded-sm cursor-default;
+  @apply relative w-full text-left bg-white border rounded-sm cursor-default text-base-gray-dark;
   padding: 10px 50px 10px 10px;
 }
 
 .selectButtonDisabled {
-  @apply bg-base-bg border-base-bg;
+  @apply text-opacity-50 bg-base-bg border-base-bg dark:bg-white dark:bg-opacity-80;
 }
 
 .selectButtonError {
@@ -36,7 +36,7 @@
 }
 
 .selectButtonText {
-  @apply grid grid-flow-col grid-rows-1 text-base truncate text-base-gray-dark gap-4 justify-between;
+  @apply grid justify-between grid-flow-col grid-rows-1 gap-4 text-base truncate;
 }
 
 .selectButtonText svg {

--- a/apps/web/src/components/select/select.module.css
+++ b/apps/web/src/components/select/select.module.css
@@ -36,7 +36,7 @@
 }
 
 .selectButtonText {
-  @apply grid justify-between grid-flow-col grid-rows-1 gap-4 text-base truncate;
+  @apply grid justify-start grid-flow-col grid-rows-1 gap-4 text-base truncate;
 }
 
 .selectButtonText svg {

--- a/apps/web/src/components/select/select.module.css
+++ b/apps/web/src/components/select/select.module.css
@@ -19,7 +19,7 @@
 }
 
 .selectContainer {
-  @apply relative z-20;
+  @apply relative;
 }
 
 .selectButton {
@@ -40,7 +40,7 @@
 }
 
 .selectButtonText svg {
-  @apply stroke-current text-base-gray-light justify-self-end;
+  @apply opacity-75 stroke-current justify-self-end;
   width: 22px;
 }
 
@@ -53,7 +53,7 @@
 }
 
 .selectOptions {
-  @apply absolute w-full py-1 mt-1 overflow-auto text-sm bg-white border rounded-sm shadow-md max-h-60;
+  @apply absolute z-10 w-full py-1 mt-1 overflow-auto text-sm bg-white border rounded-sm shadow-md max-h-60;
 }
 
 .selectOption {

--- a/apps/web/src/components/select/select.tsx
+++ b/apps/web/src/components/select/select.tsx
@@ -69,7 +69,7 @@ export default function Select({
             })}
           >
             <span className={css.selectButtonText}>
-              {Icon ? Icon : <svg viewBox={'0 0 24 24'} />}
+              {Icon ? Icon : null}
               {value.label}
             </span>
             <span className={css.selectButtonIconContainer}>

--- a/apps/web/src/contexts/theme-context.tsx
+++ b/apps/web/src/contexts/theme-context.tsx
@@ -55,8 +55,6 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
       return themeOptions[
         (themeOptions.indexOf(theme) + 1) % themeOptions.length
       ]
-      // const actualTheme = theme ?? getThemeFromBrowser()
-      // return actualTheme === 'dark' ? 'light' : 'dark'
     })
   }, [setTheme])
 

--- a/apps/web/src/contexts/theme-context.tsx
+++ b/apps/web/src/contexts/theme-context.tsx
@@ -52,9 +52,11 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
 
   const toggleTheme = useCallback(() => {
     setTheme((theme) => {
-      // return themeOptions[(themeOptions.indexOf(theme) + 1) % themeOptions.length]
-      const actualTheme = theme ?? getThemeFromBrowser()
-      return actualTheme === 'dark' ? 'light' : 'dark'
+      return themeOptions[
+        (themeOptions.indexOf(theme) + 1) % themeOptions.length
+      ]
+      // const actualTheme = theme ?? getThemeFromBrowser()
+      // return actualTheme === 'dark' ? 'light' : 'dark'
     })
   }, [setTheme])
 

--- a/apps/web/src/pages/signup.tsx
+++ b/apps/web/src/pages/signup.tsx
@@ -3,7 +3,6 @@ import useTranslation from 'next-translate/useTranslation'
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { ExtractError } from 'validator-fns'
 
-import { SelectOption } from '@/components/select/select'
 import { useAuth } from '@/contexts/auth-context'
 import { useRedemption } from '@/contexts/redemption-context'
 import { useCurrency } from '@/hooks/use-currency'
@@ -89,14 +88,6 @@ export default function SignUpPage() {
     setProfilePic(null)
   }, [])
 
-  const handleLanguageChange = useCallback((selectOption: SelectOption) => {
-    setDropdownLanguage(selectOption.id as string)
-  }, [])
-
-  const handleCurrencyChange = useCallback((selectOption: SelectOption) => {
-    setDropdownCurrency(selectOption.id as string)
-  }, [])
-
   useEffect(() => {
     if (auth.status === 'authenticated') {
       // prevent authenticated users from trying to register
@@ -118,8 +109,8 @@ export default function SignUpPage() {
         dropdownCurrency={dropdownCurrency}
         dropdownLanguage={dropdownLanguage}
         handleCreateProfile={handleCreateProfile}
-        handleCurrencyChange={handleCurrencyChange}
-        handleLanguageChange={handleLanguageChange}
+        handleCurrencyChange={setDropdownCurrency}
+        handleLanguageChange={setDropdownLanguage}
         handleProfilePicAccept={handleProfilePicAccept}
         handleProfilePicClear={handleProfilePicClear}
         error={auth.error}

--- a/apps/web/src/templates/login-email-template.tsx
+++ b/apps/web/src/templates/login-email-template.tsx
@@ -40,7 +40,7 @@ export default function LoginEmailTemplate({
             variant="red"
           />
         )}
-        <Email error={formErrors?.email} t={t} />
+        <Email error={formErrors?.email} />
         <Password
           error={formErrors?.password}
           helpLink={
@@ -48,9 +48,8 @@ export default function LoginEmailTemplate({
               {t('auth:Forgot your password?')}
             </AppLink>
           }
-          t={t}
         />
-        <Submit disabled={status === 'loading'} t={t} />
+        <Submit disabled={status === 'loading'} />
 
         <p className="mt-4 text-center">
           <AppLink href={urls.signUp}>

--- a/apps/web/src/templates/my-profile-setup-template.tsx
+++ b/apps/web/src/templates/my-profile-setup-template.tsx
@@ -41,10 +41,10 @@ export default function MyProfileSetupTemplate({
         {status === 'error' && error && (
           <AlertMessage className="mb-6" content={error} variant="red" />
         )}
-        <Username error={formErrors.username} t={t} />
-        <Passphrase error={formErrors.passphrase} t={t} />
-        <Currency error={formErrors.currency} t={t} />
-        <Submit disabled={status === 'loading'} t={t} />
+        <Username error={formErrors.username} />
+        <Passphrase error={formErrors.passphrase} />
+        <Currency error={formErrors.currency} />
+        <Submit disabled={status === 'loading'} />
       </form>
     </>
   )

--- a/apps/web/src/templates/my-profile-template.tsx
+++ b/apps/web/src/templates/my-profile-template.tsx
@@ -1,6 +1,7 @@
 import MyProfileCurrency from '@/components/profile/my-profile-currency'
 import MyProfileImage from '@/components/profile/my-profile-image'
 import MyProfileLanguage from '@/components/profile/my-profile-language'
+import MyProfileTheme from '@/components/profile/my-profile-theme'
 import MyProfileUsername from '@/components/profile/my-profile-username'
 import MyProfileWallet from '@/components/profile/my-profile-wallet'
 
@@ -10,6 +11,7 @@ export default function MyProfileTemplate() {
       <MyProfileUsername />
       <MyProfileCurrency />
       <MyProfileLanguage />
+      <MyProfileTheme />
       <MyProfileImage />
       <MyProfileWallet />
     </>

--- a/apps/web/src/templates/reset-password-template.tsx
+++ b/apps/web/src/templates/reset-password-template.tsx
@@ -51,8 +51,8 @@ export default function ResetPasswordTemplate({
             variant="green"
           />
         )}
-        <Email error={formErrors?.email} t={t} />
-        <Submit disabled={status === 'loading'} t={t} />
+        <Email error={formErrors?.email} />
+        <Submit disabled={status === 'loading'} />
 
         <p className="mt-4 text-center">
           <AppLink href={urls.signUp}>

--- a/apps/web/src/templates/signup-template.tsx
+++ b/apps/web/src/templates/signup-template.tsx
@@ -13,7 +13,6 @@ import {
   Username,
 } from '@/components/auth-inputs/auth-inputs'
 import Heading from '@/components/heading'
-import { SelectOption } from '@/components/select/select'
 import { AuthState } from '@/types/auth'
 import { FileWithPreview } from '@/types/file'
 
@@ -30,8 +29,8 @@ export interface SignupTemplateProps {
     passphrase?: unknown
   }>
   handleCreateProfile: (event: FormEvent<HTMLFormElement>) => Promise<void>
-  handleCurrencyChange: (selectOption: SelectOption) => void
-  handleLanguageChange: (selectOption: SelectOption) => void
+  handleCurrencyChange: (value: string) => void
+  handleLanguageChange: (value: string) => void
   handleProfilePicAccept: (files: File[]) => void
   handleProfilePicClear: () => void
   profilePic: FileWithPreview | null
@@ -68,29 +67,26 @@ export default function SignupTemplate({
             variant="red"
           />
         )}
-        <Email error={formErrors.email} t={t} />
-        <Username error={formErrors.username} t={t} />
-        <Password error={formErrors.password} t={t} />
+        <Email error={formErrors.email} />
+        <Username error={formErrors.username} />
+        <Password error={formErrors.password} />
         <ProfileImage
           handleProfilePicAccept={handleProfilePicAccept}
           handleProfilePicClear={handleProfilePicClear}
-          t={t}
           profilePic={profilePic}
         />
         <Language
           error={formErrors.language}
-          t={t}
           value={dropdownLanguage}
-          handleChange={handleLanguageChange}
+          onChange={handleLanguageChange}
         />
         <Currency
           error={formErrors.currency}
-          t={t}
           value={dropdownCurrency}
-          handleChange={handleCurrencyChange}
+          onChange={handleCurrencyChange}
         />
-        <Passphrase error={formErrors.passphrase} t={t} />
-        <Submit disabled={status === 'loading'} t={t} />
+        <Passphrase error={formErrors.passphrase} />
+        <Submit disabled={status === 'loading'} />
       </form>
     </>
   )


### PR DESCRIPTION
## Themes
- Enable themes in production
- FIX: app doesn't remember your selected theme
- add a listener to OS theme changes when using OS theme so it updates without refresh.
- Added Theme selection dropdown to profile page

## Other Fixes
- FIX: broken select styles and markup related to icons and z-indexing.
- FIX: make it possible to log out on mobile (button is hidden)

## Refactoring
- New `Select` input with a more standard API (`value`, `onChange`, `defaultValue`)
  - will phase out other Select in a future PR
- Reduce prop-drilling `t` into auth-inputs

https://user-images.githubusercontent.com/1179515/161835522-120d8ff4-d820-4a0a-b287-8d051447b5cc.mp4


# Darkmode fix
<img width="1027" alt="CleanShot 2022-04-05 at 10 19 27@2x" src="https://user-images.githubusercontent.com/1179515/161797993-f9e18442-9871-4482-8c7b-a11f125f644e.png">
<img width="858" alt="CleanShot 2022-04-05 at 13 05 05@2x" src="https://user-images.githubusercontent.com/1179515/161811478-96be744a-7039-48d0-97ca-8a8b571e61fc.png">

# Z-index fix
<img width="576" alt="CleanShot 2022-04-05 at 11 54 14@2x" src="https://user-images.githubusercontent.com/1179515/161798070-b82b7d14-7aa6-4446-988f-81bccd7c18a1.png">
<img width="563" alt="CleanShot 2022-04-05 at 13 05 44@2x" src="https://user-images.githubusercontent.com/1179515/161811681-b5e4c9b0-2a01-446b-b74d-ea1e874fbe22.png">

# No-icon fix
<img width="258" alt="CleanShot 2022-04-05 at 12 05 22@2x" src="https://user-images.githubusercontent.com/1179515/161798121-46f5d005-2663-4b2f-85b3-fae1ebc728e8.png">
<img width="279" alt="CleanShot 2022-04-05 at 12 06 03@2x" src="https://user-images.githubusercontent.com/1179515/161798124-497bea96-97d3-46d3-940b-21de16f556b3.png">

# No mobile logout fix
<img width="287" alt="CleanShot 2022-04-05 at 17 06 45@2x" src="https://user-images.githubusercontent.com/1179515/161849291-fae75006-111f-4d2c-b387-fc10caaf4194.png">

