### PR TITLE
Load font from Google Fonts to enable font optimization

### DIFF
--- a/apps/web/src/pages/_document.tsx
+++ b/apps/web/src/pages/_document.tsx
@@ -5,12 +5,16 @@ export default function Document() {
     <Html>
       <Head>
         {/* Base Fonts */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
-          as="style"
-          rel="preload"
-          href="https://fonts.cdnfonts.com/css/inter"
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
         />
-        <link href="https://fonts.cdnfonts.com/css/inter" rel="stylesheet" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
+          rel="stylesheet"
+        />
         <link rel="icon" href="/favicon.ico" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/favicon-180.png" />


### PR DESCRIPTION
https://nextjs.org/docs/basic-features/font-optimization

> Automatic Webfont Optimization currently supports Google Fonts and Typekit with support for other font providers coming soon. We're also planning to add control over [loading strategies](https://github.com/vercel/next.js/issues/21555) and font-display values.