### PR TITLE
Several i18n fixes

### DIFF
--- a/apps/web/src/components/app-footer/sections/app-footer-currency.tsx
+++ b/apps/web/src/components/app-footer/sections/app-footer-currency.tsx
@@ -9,7 +9,7 @@ import { useCurrency } from '@/hooks/use-currency'
 import { useLanguage } from '@/hooks/use-language'
 import { AuthService } from '@/services/auth-service'
 import { validateCurrency } from '@/utils/auth-validation'
-import { setCookie } from '@/utils/cookies-web'
+import { setCookie, setCurrencyCookie } from '@/utils/cookies-web'
 
 export default function AppFooterCurrency() {
   const { t } = useTranslation()
@@ -39,8 +39,6 @@ export default function AppFooterCurrency() {
         return
       }
 
-      setCookie(CURRENCY_COOKIE, currency, 365)
-
       if (user) {
         // Update currency
         const updateCurrency = await AuthService.instance.updateCurrency(
@@ -53,6 +51,8 @@ export default function AppFooterCurrency() {
 
         await reloadProfile()
       } else {
+        setCurrencyCookie(body.currency)
+
         // TODO: fix race condition to avoid having to do the router push when not logged in
         router.push(
           { pathname: router.pathname, query: router.query },

--- a/apps/web/src/components/app-footer/sections/app-footer-language.tsx
+++ b/apps/web/src/components/app-footer/sections/app-footer-language.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '@/contexts/auth-context'
 import { useLanguage } from '@/hooks/use-language'
 import { AuthService } from '@/services/auth-service'
 import { validateLanguage } from '@/utils/auth-validation'
-import { setCookie } from '@/utils/cookies-web'
+import { setCookie, setLanguageCookie } from '@/utils/cookies-web'
 
 export default function AppFooterLanguage() {
   const { t } = useTranslation()
@@ -37,8 +37,6 @@ export default function AppFooterLanguage() {
         return
       }
 
-      setCookie(LANG_COOKIE, language, 365)
-
       if (user) {
         // Update language
         const updateLanguage = await AuthService.instance.updateLanguage(
@@ -50,6 +48,8 @@ export default function AppFooterLanguage() {
         }
 
         await reloadProfile()
+      } else {
+        setLanguageCookie(body.language)
       }
 
       setLoading(false)

--- a/apps/web/src/components/app-link/app-link.tsx
+++ b/apps/web/src/components/app-link/app-link.tsx
@@ -4,7 +4,7 @@ import { AnchorHTMLAttributes, DetailedHTMLProps } from 'react'
 
 import css from './app-link.module.css'
 
-import { useLocale } from '@/hooks/use-locale'
+import { useLanguage } from '@/hooks/use-language'
 
 export type AppLinkProps = NextLinkProps &
   Omit<
@@ -27,12 +27,12 @@ export default function AppLink({
   className,
   ...rest
 }: AppLinkProps) {
-  const locale = useLocale()
+  const language = useLanguage()
   return (
     <Link
       href={href}
       as={as}
-      locale={locale}
+      locale={language}
       passHref={passHref}
       prefetch={prefetch}
       replace={replace}

--- a/apps/web/src/components/profile/my-profile-currency.tsx
+++ b/apps/web/src/components/profile/my-profile-currency.tsx
@@ -1,4 +1,4 @@
-import { CURRENCY_COOKIE, DEFAULT_CURRENCY } from '@algomart/schemas'
+import { DEFAULT_CURRENCY } from '@algomart/schemas'
 import { useRouter } from 'next/router'
 import useTranslation from 'next-translate/useTranslation'
 import { FormEvent, useCallback, useMemo, useState } from 'react'
@@ -14,7 +14,6 @@ import { useAuth } from '@/contexts/auth-context'
 import { useCurrency } from '@/hooks/use-currency'
 import { AuthService } from '@/services/auth-service'
 import { validateCurrency } from '@/utils/auth-validation'
-import { setCookie } from '@/utils/cookies-web'
 
 export default function MyProfileCurrency() {
   const { user, reloadProfile } = useAuth()
@@ -57,7 +56,6 @@ export default function MyProfileCurrency() {
         return
       }
 
-      setCookie(CURRENCY_COOKIE, currency, 365)
       await reloadProfile()
       setLoading(false)
       setIsEditing(false)

--- a/apps/web/src/components/profile/my-profile-language.tsx
+++ b/apps/web/src/components/profile/my-profile-language.tsx
@@ -1,4 +1,4 @@
-import { DEFAULT_LANG, LANG_COOKIE } from '@algomart/schemas'
+import { DEFAULT_LANG } from '@algomart/schemas'
 import { useRouter } from 'next/router'
 import useTranslation from 'next-translate/useTranslation'
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
@@ -14,7 +14,6 @@ import { useAuth } from '@/contexts/auth-context'
 import { useLanguage } from '@/hooks/use-language'
 import { AuthService } from '@/services/auth-service'
 import { validateLanguage } from '@/utils/auth-validation'
-import { setCookie } from '@/utils/cookies-web'
 
 export default function MyProfileLanguage() {
   const language = useLanguage()
@@ -58,7 +57,6 @@ export default function MyProfileLanguage() {
         return
       }
 
-      setCookie(LANG_COOKIE, body.language, 365)
       await reloadProfile()
       setLoading(false)
       setIsEditing(false)

--- a/apps/web/src/contexts/auth-context.tsx
+++ b/apps/web/src/contexts/auth-context.tsx
@@ -160,6 +160,8 @@ export function useAuthProvider() {
           ...profile,
           username: profileResponse?.username || null,
           address: profileResponse?.address || null,
+          currency: profileResponse?.currency || null,
+          language: profileResponse?.language || null,
         })
       )
     }

--- a/apps/web/src/contexts/auth-context.tsx
+++ b/apps/web/src/contexts/auth-context.tsx
@@ -1,3 +1,4 @@
+import { CURRENCY_COOKIE, LANG_COOKIE } from '@algomart/schemas'
 import {
   Auth,
   createUserWithEmailAndPassword,
@@ -34,7 +35,7 @@ import {
   SignUpPayload,
 } from '@/types/auth'
 import { FileWithPreview } from '@/types/file'
-import { removeCookie, setCookie } from '@/utils/cookies-web'
+import { getCookie, removeCookie, setCookie } from '@/utils/cookies-web'
 import {
   ActionsUnion,
   createAction,
@@ -146,6 +147,48 @@ export function useAuthProvider() {
       if (profileResponse.email !== auth.currentUser.email) {
         await fetch(urls.api.v1.updateEmail, {
           body: JSON.stringify({ email: auth.currentUser.email }),
+          headers: {
+            authorization: `bearer ${token}`,
+            'content-type': 'application/json',
+          },
+          method: 'PUT',
+        })
+      }
+
+      /**
+       * If an anonymous user changes their preferred language, then logs in,
+       * we need to update the db to reflect this preference
+       */
+      const languageCookie = getCookie(LANG_COOKIE)
+      const parsedLanguageCookie =
+        languageCookie && languageCookie !== 'null' ? languageCookie : null
+      if (
+        parsedLanguageCookie &&
+        profileResponse.language !== parsedLanguageCookie
+      ) {
+        await fetch(urls.api.v1.updateLanguage, {
+          body: JSON.stringify({ parsedLanguageCookie }),
+          headers: {
+            authorization: `bearer ${token}`,
+            'content-type': 'application/json',
+          },
+          method: 'PUT',
+        })
+      }
+
+      /**
+       * If an anonymous user changes their preferred currency, then logs in,
+       * we need to update the db to reflect this preference
+       */
+      const currencyCookie = getCookie(CURRENCY_COOKIE)
+      const parsedCurrencyCookie =
+        currencyCookie && currencyCookie !== 'null' ? currencyCookie : null
+      if (
+        parsedCurrencyCookie &&
+        profileResponse.currency !== parsedCurrencyCookie
+      ) {
+        await fetch(urls.api.v1.updateCurrency, {
+          body: JSON.stringify({ parsedCurrencyCookie }),
           headers: {
             authorization: `bearer ${token}`,
             'content-type': 'application/json',

--- a/apps/web/src/pages/signup.tsx
+++ b/apps/web/src/pages/signup.tsx
@@ -12,6 +12,7 @@ import { AuthService } from '@/services/auth-service'
 import SignupTemplate from '@/templates/signup-template'
 import { FileWithPreview } from '@/types/file'
 import { validateEmailAndPasswordRegistration } from '@/utils/auth-validation'
+import { setCurrencyCookie, setLanguageCookie } from '@/utils/cookies-web'
 import { urls } from '@/utils/urls'
 
 export default function SignUpPage() {
@@ -60,6 +61,8 @@ export default function SignUpPage() {
 
       const result = await auth.registerWithEmailAndPassword(body)
       if (result.isValid) {
+        setCurrencyCookie(body.currency)
+        setLanguageCookie(body.language)
         await auth.reloadProfile()
         router.push(redeemable ? urls.login : urls.home, undefined, {
           locale: body.language,

--- a/apps/web/src/services/auth-service.ts
+++ b/apps/web/src/services/auth-service.ts
@@ -2,6 +2,7 @@ import { DEFAULT_CURRENCY, DEFAULT_LANG } from '@algomart/schemas'
 import { getAuth } from 'firebase/auth'
 import ky from 'ky'
 
+import { setCurrencyCookie, setLanguageCookie } from '@/utils/cookies-web'
 import { invariant } from '@/utils/invariant'
 import { urls } from '@/utils/urls'
 
@@ -65,6 +66,9 @@ export class AuthService implements AuthAPI {
       await this.http
         .put(urls.api.v1.updateLanguage, { json: { language } })
         .json()
+
+      setLanguageCookie(language)
+
       return true
     } catch {
       return false
@@ -80,6 +84,9 @@ export class AuthService implements AuthAPI {
       await this.http
         .put(urls.api.v1.updateCurrency, { json: { currency } })
         .json()
+
+      setCurrencyCookie(currency)
+
       return true
     } catch {
       return false

--- a/apps/web/src/utils/cookies-web.ts
+++ b/apps/web/src/utils/cookies-web.ts
@@ -1,3 +1,4 @@
+import { CURRENCY_COOKIE, LANG_COOKIE } from '@algomart/schemas'
 import Cookies from 'js-cookie'
 
 export function setCookie(name: string, value: string, expiresInDays: number) {
@@ -12,4 +13,12 @@ export function getCookie(name: string): string | undefined {
 
 export function removeCookie(name: string) {
   Cookies.remove(name)
+}
+
+export function setCurrencyCookie(currency: string) {
+  setCookie(CURRENCY_COOKIE, currency, 365)
+}
+
+export function setLanguageCookie(language: string) {
+  setCookie(LANG_COOKIE, language, 365)
 }


### PR DESCRIPTION
- Fix: app-link was being passed locale, not language (they are distinct)
- Fix: Signup flow currency/language choices were not being reflected in the footer after successful signup
- Fix: Anonymous footer currency/language choices were not updating user profile once logged in
- Refactor: Auth service updateCurrency and updateLanguage updates cookies, reducing cookie setting duplication
  - @afraser annoyingly the app-footer-language and app-footer-currency components still need to set them manually, if you're logged out
- Refactor: Made specific setCurrency and setLanguage cookie utils to minimize additional code duplication