### PR TITLE
create collectible listings table

### DIFF
--- a/apps/scribe/src/migrations/20220428190347_collectible_listings.ts
+++ b/apps/scribe/src/migrations/20220428190347_collectible_listings.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('CollectibleListings', (table) => {
+    table.uuid('id').primary()
+    table
+      .uuid('collectibleId')
+      .references('id')
+      .inTable('Collectible')
+      .notNullable()
+    table.integer('price').notNullable()
+    table.text('type').notNullable()
+    table.timestamp('expiresAt')
+    table.timestamp('createdAt').defaultTo(knex.fn.now()).notNullable()
+    table.timestamp('updatedAt').defaultTo(knex.fn.now()).notNullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('CollectibleListings')
+}


### PR DESCRIPTION
Table to hold information on a listing for querying and display purposes

CollectibleListings
- id - uuid
- collectibleId - FK Collectible.id
- price - number
- type - [purchase, auction]
- expiresAt - Date
- createdAt - Date
- updatedAt - Date

Could potentially expand this table down the line to include things like:
- Flag for archived or not (current strategy is to delete row when listing removed or completed)
- Flag for status, potentially to hold an "in flight" state if someone else is already in the purchase flow for the Listing