### PR TITLE
Minor fixes to CMS env.sample and README

### DIFF
--- a/apps/cms/.env.example
+++ b/apps/cms/.env.example
@@ -6,8 +6,10 @@ PUBLIC_URL="http://localhost:8055"
 # Quieter logs (see: https://docs.directus.io/reference/environment-variables/#general )
 # LOG_LEVEL="warn"
 
-ADMIN_EMAIL="" ;any email. used for directus login
-ADMIN_PASSWORD="" ;any email. used for directus login
+# Any email, used for directus login
+ADMIN_EMAIL=""
+# Any password, used for directus login
+ADMIN_PASSWORD=""
 
 ####################################################################################################
 ## Database

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -41,7 +41,14 @@ npm run seed
 To initialize the CMS database:
 
 ```bash
-nx drop cms &&\
+nx drop cms
+```
+
+```sql
+CREATE SCHEMA "cms"
+```
+
+```bash
 nx bootstrap cms &&\
 nx import cms
 ```


### PR DESCRIPTION
When initializing the DB with the .env.sample given, the Directus login e-mail and password values in the DB table were being set to also include the '; any email, used for directus login' comment because it seems the ; wasn't recognized so I changed it to use #.

Also, in the README the CREATE SCHEMA cms needs to be run after dropping the schema and before initializing/bootstrapping so I added this step.